### PR TITLE
AtMostOne handles nulls in collections sensibly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.14</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -335,7 +335,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>HEAD</tag>
+        <tag>0.14</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>0.14</version>
+    <version>1.0-SNAPSHOT</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -335,7 +335,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>0.14</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/util/AtMostOne.java
+++ b/src/main/java/no/digipost/util/AtMostOne.java
@@ -42,7 +42,7 @@ public interface AtMostOne<T> extends ViewableAsOptional<T> {
             @Override
             public <X extends Throwable> Optional<T> orElse(ThrowingRunnable<X> handleUnexpectedMultipleElements) throws X {
                 Iterator<T> iterator = iterable.iterator();
-                final Optional<T> expected = iterator.hasNext() ? Optional.of(iterator.next()) : Optional.empty();
+                final Optional<T> expected = iterator.hasNext() ? Optional.ofNullable(iterator.next()) : Optional.empty();
                 if (iterator.hasNext()) {
                     handleUnexpectedMultipleElements.run();
                 }
@@ -66,9 +66,10 @@ public interface AtMostOne<T> extends ViewableAsOptional<T> {
     /**
      * Get the at most single contained element, or throw a {@link TooManyElements} exception
      * if there are excessive elements available. If you need control over the thrown exception, use
-     * {@link #orIfExcessiveThrow(Supplier)}
+     * {@link #orIfExcessiveThrow(Supplier)}.
      *
-     * @return The single element if it exists, or {@link Optional#empty()} if no elements exist.
+     * @return The single element if it exists, or else {@link Optional#empty()} if no elements exist or
+     *         the single element is {@code null}.
      */
     @Override
     default Optional<T> toOptional() {

--- a/src/test/java/no/digipost/DiggCollectorsTest.java
+++ b/src/test/java/no/digipost/DiggCollectorsTest.java
@@ -103,6 +103,13 @@ public class DiggCollectorsTest {
     public void collectTheValueOfSingleElementStream() {
         assertThat(Stream.of(42).collect(allowAtMostOne()), contains(is(42)));
         assertThat(Stream.empty().collect(allowAtMostOne()), OptionalMatchers.empty());
+        assertThat(Stream.of((String) null).collect(allowAtMostOne()), OptionalMatchers.empty());
+    }
+
+    @Test
+    public void allowAtMostOneFailsEvenIfExcessiveElementsAreNull() {
+        expectedException.expect(ViewableAsOptional.TooManyElements.class);
+        Stream.of("x", null).collect(allowAtMostOne());
     }
 
     @Property

--- a/src/test/java/no/digipost/util/AtMostOneTest.java
+++ b/src/test/java/no/digipost/util/AtMostOneTest.java
@@ -48,12 +48,17 @@ public class AtMostOneTest {
     @Test
     public void picksOutFirstElementInSingleElementList() {
         assertThat(AtMostOne.from(singleton("a")).toOptional().get(), is("a"));
+        assertThat(AtMostOne.from(singleton(null)).toOptional(), is(Optional.empty()));
     }
 
     @Test
     public void handleExcessiveElements() {
         OneTimeToggle excessiveElements = new OneTimeToggle();
         AtMostOne.from(asList("a", "b")).orElse(excessiveElements::now);
+        assertTrue(excessiveElements.yet());
+
+        OneTimeToggle excessiveNull = new OneTimeToggle();
+        AtMostOne.from(asList("a", null)).orElse(excessiveNull::now);
         assertTrue(excessiveElements.yet());
     }
 


### PR DESCRIPTION
Similar bug as already fixed in
65beedb87f2099110152e91cb1fc7239d849400d.