### PR TITLE
try-with-resources for arbitrary objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ _Digg_ requires Java 8, and has no other dependencies.
 
 _Digg_ contains a lot of useful utilities implemented as static methods. The "entry point" for these methods are all classes with the prefix `Digg*`. An easy way to explore the API is to type `Digg` in your IDE, and let auto-completion show you what is available.
 
-![Auto-complete in an IDE](https://digipost.github.io/digg/img/digg-autocomplete.png)
+![Auto-complete in an IDE](https://digipost.github.io/digg/img/digg-autocomplete.png?nocache=1)
 
 Javadocs are available at [javadoc.io/doc/no.digipost/digg](http://www.javadoc.io/doc/no.digipost/digg)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Digg_ is available in [![Maven Central Repository](https://maven-badges.herokua
 <dependency>
     <groupId>no.digipost</groupId>
     <artifactId>digg</artifactId>
-    <version>0.13</version>
+    <version>0.15</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.15</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -335,7 +335,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>HEAD</tag>
+        <tag>0.15</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>0.15</version>
+    <version>1.0-SNAPSHOT</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -335,7 +335,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>0.15</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -15,6 +15,9 @@
  */
 package no.digipost;
 
+import no.digipost.function.ThrowingConsumer;
+import no.digipost.util.AutoClosed;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
@@ -180,6 +183,15 @@ public final class DiggBase {
         return extract(object, extractors).filter(Optional::isPresent).map(Optional::get);
     }
 
+
+    public static <T, X extends Exception> AutoClosed<T, X> autoClose(T object, ThrowingConsumer<? super T, X> closeOperation) {
+        return new AutoClosed<T, X>(object, closeOperation);
+    }
+
+
     private DiggBase() {}
+
+
+
 
 }

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -237,7 +237,4 @@ public final class DiggBase {
 
     private DiggBase() {}
 
-
-
-
 }

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -17,10 +17,12 @@ package no.digipost;
 
 import no.digipost.function.ThrowingConsumer;
 import no.digipost.util.AutoClosed;
+import no.digipost.util.ThrowingAutoClosed;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -184,8 +186,52 @@ public final class DiggBase {
     }
 
 
-    public static <T, X extends Exception> AutoClosed<T, X> autoClose(T object, ThrowingConsumer<? super T, X> closeOperation) {
-        return new AutoClosed<T, X>(object, closeOperation);
+    /**
+     * Wrap an arbitrary object to an {@link AutoCloseable} container, and assign an operation to be
+     * performed on the wrapped object when calling {@link AutoCloseable#close()}. This can be
+     * used for legacy classes which does not implement {@code AutoCloseable} to be used with the
+     * {@code try-with-resources} construct. It should not be used (although it <em>can</em>) for
+     * objects already implementing {@code AutoCloseable}.
+     *
+     * @param object the object to be managed with {@code try-with-resources}.
+     * @param closeOperation the operation to invoke on {@code object} to close it.
+     *
+     * @return The wrapper which is {@link AutoCloseable}. Assign this with {@code try-with-resources} to
+     *         have it properly closed.
+     *
+     *
+     * @param <T> The type of the wrapped/managed object.
+     * @param <X> The exception which may be throwed when closing by {@link AutoCloseable#close()}.
+     *
+     * @see #autoClose(Object, Consumer)
+     */
+    public static <T, X extends Exception> ThrowingAutoClosed<T, X> throwingAutoClose(T object, ThrowingConsumer<? super T, X> closeOperation) {
+        return new ThrowingAutoClosed<T, X>(object, closeOperation);
+    }
+
+
+    /**
+     * Wrap an arbitrary object to an {@link AutoCloseable} container, and assign an operation to be
+     * performed on the wrapped object when calling {@link AutoCloseable#close()}. This can be
+     * used for legacy classes which does not implement {@code AutoCloseable} to be used with the
+     * {@code try-with-resources} construct. It should not be used (although it <em>can</em>) for
+     * objects already implementing {@code AutoCloseable}.
+     *
+     * @param object the object to be managed with {@code try-with-resources}.
+     * @param closeOperation the operation to invoke on {@code object} to close it. If the operation
+     *                       can throw a checked exception, use {@link #throwingAutoClose(Object, ThrowingConsumer)}
+     *                       instead.
+     *
+     * @return The wrapper which is {@link AutoCloseable}. Assign this with {@code try-with-resources} to
+     *         have it properly closed.
+     *
+     *
+     * @param <T> The type of the wrapped/managed object.
+     *
+     * @see #throwingAutoClose(Object, ThrowingConsumer)
+     */
+    public static <T> AutoClosed<T> autoClose(T object, Consumer<? super T> closeOperation) {
+        return new AutoClosed<T>(object, closeOperation);
     }
 
 

--- a/src/main/java/no/digipost/util/AutoCloseableAdapter.java
+++ b/src/main/java/no/digipost/util/AutoCloseableAdapter.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.util;
+
+import no.digipost.function.ThrowingConsumer;
+
+import static no.digipost.DiggExceptions.runUnchecked;
+
+abstract class AutoCloseableAdapter<T, X extends Exception> {
+    private final T managedObject;
+    private final ThrowingConsumer<? super T, X> closeOperation;
+
+    protected AutoCloseableAdapter(T managedObject, ThrowingConsumer<? super T, X> closeOperation) {
+        this.managedObject = managedObject;
+        this.closeOperation = closeOperation;
+    }
+
+    /**
+     * @return the object managed by try-with-resources.
+     */
+    public T object() {
+        return managedObject;
+    }
+
+    /**
+     * @see AutoCloseable#close()
+     */
+    public void close() throws X {
+        closeOperation.accept(managedObject);
+        if (managedObject instanceof AutoCloseable) {
+            runUnchecked(() -> ((AutoCloseable) managedObject).close());
+        }
+    }
+
+}

--- a/src/main/java/no/digipost/util/AutoClosed.java
+++ b/src/main/java/no/digipost/util/AutoClosed.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.util;
+
+import no.digipost.function.ThrowingConsumer;
+
+import static no.digipost.DiggExceptions.runUnchecked;
+
+/**
+ * An adapter to enable any arbitrary object to be managed by the
+ * <em>try-with-resources</em> facility of Java >= 7, i.e. it will have a
+ * closing operation invoked when exiting the {@code try}-block.
+ *
+ * @param <T> The type of the arbitrary object which will have an operation invoked
+ *            on exiting from a try-with-resources block.
+ * @param <X> The type of exception which may be throwed by the {@code closeOperation}
+ */
+public final class AutoClosed<T, X extends Exception> implements AutoCloseable {
+
+    private final T managedObject;
+    private final ThrowingConsumer<? super T, X> closeOperation;
+
+    public AutoClosed(T managedObject, ThrowingConsumer<? super T, X> closeOperation) {
+        this.managedObject = managedObject;
+        this.closeOperation = closeOperation;
+    }
+
+    /**
+     * @return the object managed by try-with-resources.
+     */
+    public T object() {
+        return managedObject;
+    }
+
+    @Override
+    public void close() throws X {
+        closeOperation.accept(managedObject);
+        if (managedObject instanceof AutoCloseable) {
+            runUnchecked(() -> ((AutoCloseable) managedObject).close());
+        }
+    }
+
+
+}

--- a/src/main/java/no/digipost/util/ThrowingAutoClosed.java
+++ b/src/main/java/no/digipost/util/ThrowingAutoClosed.java
@@ -15,7 +15,7 @@
  */
 package no.digipost.util;
 
-import java.util.function.Consumer;
+import no.digipost.function.ThrowingConsumer;
 
 /**
  * An adapter to enable any arbitrary object to be managed by the
@@ -24,11 +24,12 @@ import java.util.function.Consumer;
  *
  * @param <T> The type of the arbitrary object which will have an operation invoked
  *            on exiting from a try-with-resources block.
+ * @param <X> The type of exception which may be throwed by the {@code closeOperation}
  */
-public final class AutoClosed<T> extends AutoCloseableAdapter<T, RuntimeException> implements AutoCloseable {
+public final class ThrowingAutoClosed<T, X extends Exception> extends AutoCloseableAdapter<T, X> implements AutoCloseable {
 
-    public AutoClosed(T managedObject, Consumer<? super T> closeOperation) {
-        super(managedObject, closeOperation::accept);
+    public ThrowingAutoClosed(T managedObject, ThrowingConsumer<? super T, X> closeOperation) {
+        super(managedObject, closeOperation);
     }
 
 }

--- a/src/test/java/no/digipost/DiggBaseTest.java
+++ b/src/test/java/no/digipost/DiggBaseTest.java
@@ -18,15 +18,19 @@ package no.digipost;
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.When;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import no.digipost.util.AutoClosed;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 
+import java.io.IOException;
 import java.util.Optional;
 
 import static co.unruly.matchers.StreamMatchers.contains;
 import static co.unruly.matchers.StreamMatchers.empty;
+import static no.digipost.DiggBase.autoClose;
 import static no.digipost.DiggBase.friendlyName;
 import static no.digipost.DiggBase.nonNull;
 import static org.hamcrest.Matchers.is;
@@ -34,6 +38,12 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(JUnitQuickcheck.class)
 public class DiggBaseTest {
@@ -98,7 +108,41 @@ public class DiggBaseTest {
         assertThat(friendlyName(InMethod.class), is(getClass().getSimpleName() + ".InMethod"));
     }
 
+    @Test
+    public void objectManagedByAutoCloseIsSameInstanceAsGiven() {
+        Object object = new Object();
+        AutoClosed<Object, RuntimeException> managed = autoClose(object, o -> {});
+        assertThat(managed.object(), sameInstance(object));
+    }
 
+
+    @Test
+    public void useArbitraryObjectWithTryWithResources() {
+        abstract class MyResource {
+            abstract void done();
+        }
+        MyResource resource = mock(MyResource.class);
+        try (AutoClosed<MyResource, RuntimeException> managedResource = autoClose(resource, MyResource::done)) {
+            verifyZeroInteractions(resource);
+        }
+        verify(resource, times(1)).done();
+        verifyNoMoreInteractions(resource);
+    }
+
+    @Test
+    public void wrappingAnAlreadyAutoCloseableWithAutoCloseWillAlsoInvokeClose() throws Exception {
+        abstract class MyResource implements AutoCloseable {
+            abstract void done() throws IOException;
+        }
+        MyResource resource = mock(MyResource.class);
+        try (AutoClosed<MyResource, IOException> managedResource = autoClose(resource, MyResource::done)) {
+            verifyZeroInteractions(resource);
+        }
+        InOrder inOrder = inOrder(resource);
+        inOrder.verify(resource, times(1)).done();
+        inOrder.verify(resource, times(1)).close();
+        inOrder.verifyNoMoreInteractions();
+    }
 
 
 }

--- a/src/test/java/no/digipost/DiggBaseTest.java
+++ b/src/test/java/no/digipost/DiggBaseTest.java
@@ -159,7 +159,6 @@ public class DiggBaseTest {
         verifyNoMoreInteractions(resource);
     }
 
-
 }
 
 


### PR DESCRIPTION
Some legacy classes does not implement [AutoCloseable](https://docs.oracle.com/javase/8/docs/api/java/lang/AutoCloseable.html), but should still be closed in order to release resources. This adds an adapter to enable such classes to be used with `try-with-resources`.