### PR TITLE
Close and collect exceptions as suppressed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>0.16</version>
+    <version>1.0-SNAPSHOT</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -335,7 +335,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>0.16</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.16</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -335,7 +335,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>HEAD</tag>
+        <tag>0.16</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>co.unruly</groupId>
             <artifactId>java-8-matchers</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -189,11 +189,21 @@ public final class DiggBase {
 
     /**
      * Create a stream which will yield the exceptions from closing several {@link AutoCloseable closeables}.
-     * Consuming the stream will ensure that <strong>all</strong> closeables are attempted {@link AutoCloseable#close() closed},
-     * and any exceptions happening will be available through the returned stream.
+     * Consuming the stream will ensure that <strong>all</strong> closeables are attempted
+     * {@link AutoCloseable#close() closed}, and any exceptions happening will be available
+     * through the returned stream.
+     * <p>
+     * To further collapse the possibly multiple exceptions into <em>one</em> throwable exception,
+     * use either
+     * {@link DiggCollectors#toSingleExceptionWithSuppressed() .collect(toSingleExceptionWithSuppressed())}
+     * or {@link DiggCollectors#asSuppressedExceptionsOf(Throwable) .collect(asSuppressedExceptionsOf(..))}
+     * in {@code DiggCollectors}.
      *
      * @param closeables The {@code AutoCloseable} instances to close.
      * @return the Stream with exceptions, if any, from closing the closeables
+     *
+     * @see DiggCollectors#toSingleExceptionWithSuppressed()
+     * @see DiggCollectors#asSuppressedExceptionsOf(Throwable)
      */
     public static Stream<Exception> close(AutoCloseable ... closeables) {
         return Stream.of(closeables).filter(Objects::nonNull).flatMap(closeable -> {

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -21,6 +21,7 @@ import no.digipost.util.ThrowingAutoClosed;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -183,6 +184,26 @@ public final class DiggBase {
     @SafeVarargs
     public static final <T, R> Stream<R> extractIfPresent(T object, Function<? super T, ? extends Optional<R>> ... extractors) {
         return extract(object, extractors).filter(Optional::isPresent).map(Optional::get);
+    }
+
+
+    /**
+     * Create a stream which will yield the exceptions from closing several {@link AutoCloseable closeables}.
+     * Consuming the stream will ensure that <strong>all</strong> closeables are attempted {@link AutoCloseable#close() closed},
+     * and any exceptions happening will be available through the returned stream.
+     *
+     * @param closeables The {@code AutoCloseable} instances to close.
+     * @return the Stream with exceptions, if any, from closing the closeables
+     */
+    public static Stream<Exception> close(AutoCloseable ... closeables) {
+        return Stream.of(closeables).filter(Objects::nonNull).flatMap(closeable -> {
+            try {
+                closeable.close();
+            } catch (Exception closeException) {
+                return Stream.of(closeException);
+            }
+            return Stream.empty();
+        });
     }
 
 


### PR DESCRIPTION
Add facility to close several Closeables, and not loose any exceptions, for cases where the try-with-resources construct is not applicable.

It can be used like this:
```java
...
} catch (SomeException e) {
    throw close(closeable1, closeable2, closeable3).collect(asSuppressedExceptionsOf(e));
}
```

Or, like this:
```java
...
} finally {
    close(closeable1, closeable2, closeable3)
        .collect(toSingleExceptionWithSuppressed())
        .map(DiggExceptions::asUnchecked)
        .ifPresent(e -> { throw e; });
}
```