### PR TITLE
Add column mappers to retrieve arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Digg_ is available in [![Maven Central Repository](https://maven-badges.herokua
 <dependency>
     <groupId>no.digipost</groupId>
     <artifactId>digg</artifactId>
-    <version>0.19</version>
+    <version>0.20</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <compilerArgs>
                             <arg>-Xlint</arg>
@@ -233,7 +233,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -246,7 +246,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.13.0</version>
+                    <version>0.14.1</version>
                     <configuration>
                         <newVersion>
                             <file><path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path></file>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>2</version>
+        <version>3</version>
     </parent>
 
     <artifactId>digg</artifactId>
@@ -143,9 +143,6 @@
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
-                    <configuration>
-                        <scmCommentPrefix>Release [ci skip]:</scmCommentPrefix>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,31 +48,31 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.0</version>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.0</version>
+            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.1</version>
+            <version>2.2-rc1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.24.5</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.0.1-jre</version>
+            <version>28.1-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.1.5</version>
+            <version>3.1.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -134,18 +134,6 @@
                     <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.25</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -287,8 +275,6 @@
                             <failOnWarning>true</failOnWarning>
                             <usedDependencies>
                                 <usedDependency>org.junit.jupiter:junit-jupiter-engine</usedDependency>
-                                <usedDependency>org.slf4j:slf4j-simple</usedDependency>
-                                <usedDependency>org.slf4j:jcl-over-slf4j</usedDependency>
                             </usedDependencies>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.20</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -295,7 +295,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>HEAD</tag>
+        <tag>0.20</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>0.20</version>
+    <version>1.0-SNAPSHOT</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -295,7 +295,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>0.20</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/function/ThrowingFunction.java
+++ b/src/main/java/no/digipost/function/ThrowingFunction.java
@@ -72,7 +72,11 @@ public interface ThrowingFunction<T, R, X extends Throwable> {
     }
 
     default <V> ThrowingFunction<T, V, X> andThen(ThrowingFunction<? super R, V, ? extends X> after) {
-        return (t) -> after.apply(apply(t));
+        return t -> after.apply(apply(t));
+    }
+
+    default <V> ThrowingFunction<V, R, X> compose(ThrowingFunction<? super V, ? extends T, ? extends X> before) {
+        return t -> apply(before.apply(t));
     }
 
 }

--- a/src/main/java/no/digipost/jdbc/Mappers.java
+++ b/src/main/java/no/digipost/jdbc/Mappers.java
@@ -231,14 +231,7 @@ public final class Mappers {
      * @see #getIntArray
      * @see #getLongArray
      */
-    public static final BasicColumnMapper<Object> getArray = (name, rs) -> {
-        Array sqlArray = getSqlArray.map(name, rs);
-        try {
-            return sqlArray.getArray();
-        } finally {
-            sqlArray.free();
-        }
-    };
+    public static final BasicColumnMapper<Object> getArray = (name, rs) -> getSqlArray.andThen(SqlArray::of).map(name, rs).consume(Array::getArray);
 
     /**
      * Gets the value of a given SQL {@code ARRAY} column as an {@code String[]} array.

--- a/src/main/java/no/digipost/jdbc/Mappers.java
+++ b/src/main/java/no/digipost/jdbc/Mappers.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.sql.Array;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -218,6 +219,41 @@ public final class Mappers {
     public static final BasicColumnMapper<Reader> getCharacterStream = (name, rs) -> rs.getCharacterStream(name);
     /** @see ResultSet#getCharacterStream(String) */
     public static final NullableColumnMapper<Reader> getNullableCharacterStream = (name, rs) -> ofNullable(rs.getCharacterStream(name));
+
+    /** @see ResultSet#getArray(String) */
+    public static final BasicColumnMapper<Array> getSqlArray = (name, rs) -> rs.getArray(name);
+
+    /**
+     * Gets the value of a given SQL {@code ARRAY} column as an uncasted Java array object. The result should be casted to
+     * the applicable specific array type.
+     *
+     * @see #getStringArray
+     * @see #getIntArray
+     * @see #getLongArray
+     */
+    public static final BasicColumnMapper<Object> getArray = (name, rs) -> {
+        Array sqlArray = getSqlArray.map(name, rs);
+        try {
+            return sqlArray.getArray();
+        } finally {
+            sqlArray.free();
+        }
+    };
+
+    /**
+     * Gets the value of a given SQL {@code ARRAY} column as an {@code String[]} array.
+     */
+    public static final BasicColumnMapper<String[]> getStringArray = getArray.andThen(String[].class::cast);
+
+    /**
+     * Gets the value of a given SQL {@code ARRAY} column as an {@code int[]} array.
+     */
+    public static final BasicColumnMapper<int[]> getIntArray = getArray.andThen(int[].class::cast);
+
+    /**
+     * Gets the value of a given SQL {@code ARRAY} column as an {@code long[]} array.
+     */
+    public static final BasicColumnMapper<long[]> getLongArray = getArray.andThen(long[].class::cast);
 
 
     private Mappers() {}

--- a/src/main/java/no/digipost/jdbc/SqlArray.java
+++ b/src/main/java/no/digipost/jdbc/SqlArray.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.jdbc;
+
+import no.digipost.function.ThrowingFunction;
+
+import java.sql.Array;
+import java.sql.SQLException;
+
+final class SqlArray {
+
+    static SqlArray of(java.sql.Array array) {
+        return new SqlArray(array);
+    }
+
+
+    private final Array array;
+
+    private SqlArray(Array array) {
+        this.array = array;
+    }
+
+    /**
+     * Consume the contained {@link java.sql.Array} to produce a result, and ensure
+     * {@link Array#free()} is invoked.
+     *
+     * @param <R> The result type,
+     * @param sqlArrayConsumer the function to produce a result from the {@code Array}.
+     *
+     * @return the result from the given {@code sqlArrayConsumer}.
+     */
+    <R> R consume(ThrowingFunction<Array, R, SQLException> sqlArrayConsumer) throws SQLException {
+        try {
+            return sqlArrayConsumer.apply(array);
+        } finally {
+            array.free();
+        }
+    }
+
+}


### PR DESCRIPTION
Added some mappers to be able to retrieve arrays from `ResultSet`.

`no.digipost.jdbc.Mappers.getSqlArray` is the `ColumnMapper` implementation of [`ResultSet.getArray(String)`](https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html#getArray-java.lang.String-), which retrieves a [`java.sql.Array`](https://docs.oracle.com/javase/8/docs/api/java/sql/Array.html).

In addition, there are mappers to directly resolve the SQL `ARRAY` as Java arrays of type `String[]`, `int[]`, `long[]`, or, if none of these are applicable, as a general `Object` which needs to be casted. The Java array mappers will ensure [`Array.free()`](https://docs.oracle.com/javase/8/docs/api/java/sql/Array.html#free--) is invoked.