### PR TITLE
Support for threadsafe at-most-once execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ _Digg_ is available in [![Maven Central Repository](https://maven-badges.herokua
 <dependency>
     <groupId>no.digipost</groupId>
     <artifactId>digg</artifactId>
-    <version>0.20</version>
+    <version>0.21</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>0.21</version>
+    <version>1.0-SNAPSHOT</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -295,7 +295,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>0.21</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>digg</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.21</version>
     <name>Digipost Digg</name>
     <description>Some stellar general purpose utils.</description>
     <url>https://github.com/digipost/digg/</url>
@@ -295,7 +295,7 @@
         <connection>scm:git:git@github.com:digipost/digg.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digg.git</developerConnection>
         <url>https://github.com/digipost/digg/</url>
-        <tag>HEAD</tag>
+        <tag>0.21</tag>
     </scm>
 
 </project>

--- a/src/test/java/no/digipost/concurrent/OneTimeToggleTest.java
+++ b/src/test/java/no/digipost/concurrent/OneTimeToggleTest.java
@@ -17,6 +17,8 @@ package no.digipost.concurrent;
 
 import org.junit.jupiter.api.Test;
 
+import static co.unruly.matchers.Java8Matchers.where;
+import static co.unruly.matchers.Java8Matchers.whereNot;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,18 +29,18 @@ public class OneTimeToggleTest {
 
     @Test
     public void toggleIsAllowedSeveralTimes() {
-        assertThat(done.yet(), is(false));
+        assertThat(done, whereNot(OneTimeToggle::yet));
         done.now();
-        assertThat(done.yet(), is(true));
+        assertThat(done, where(OneTimeToggle::yet));
         done.now();
-        assertThat(done.yet(), is(true));
+        assertThat(done, where(OneTimeToggle::yet));
     }
 
     @Test
     public void toggleOnceOrThrowException() {
-        assertThat(done.yet(), is(false));
+        assertThat(done, whereNot(OneTimeToggle::yet));
         done.nowOrIfAlreadyThenThrow(IllegalStateException::new);
-        assertThat(done.yet(), is(true));
+        assertThat(done, where(OneTimeToggle::yet));
 
         assertThrows(IllegalStateException.class, () -> done.nowOrIfAlreadyThenThrow(IllegalStateException::new));
     }

--- a/src/test/java/no/digipost/concurrent/OneTimeToggleTest.java
+++ b/src/test/java/no/digipost/concurrent/OneTimeToggleTest.java
@@ -59,8 +59,8 @@ public class OneTimeToggleTest {
     @Test
     void toggleAndExecuteAtMostOnce() {
         AtomicInteger counter = new AtomicInteger(0);
-        done.nowAndUnlessAlreadyToggled(counter::incrementAndGet);
-        done.nowAndUnlessAlreadyToggled(counter::incrementAndGet);
+        done.nowAndUnlessAlreadyToggled(() -> { counter.incrementAndGet(); });
+        done.nowAndUnlessAlreadyToggled(() -> { counter.incrementAndGet(); });
         assertThat(done, where(OneTimeToggle::yet));
         assertThat(counter, where(Number::intValue, is(1)));
 


### PR DESCRIPTION
Implemented in `OneTimeToggle`, as two method overloads of `nowAndUnlessAlreadyToggled(..)` which will ensure that a Runnable or Supplier is run at most one time, even if several threads are trying to invoke it. Test is _really_ stressing the execution of this code to ensure this.

When developing, I started with implementing the naïve non-threadsafe version of this logic to verify that the test actually detects this.