### PR TITLE
Tuple convertor methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _Digg_ is available in [![Maven Central Repository](https://maven-badges.herokua
 <dependency>
     <groupId>no.digipost</groupId>
     <artifactId>digg</artifactId>
-    <version>0.22</version>
+    <version>0.23</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila</groupId>
@@ -151,7 +151,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
+                    <version>3.0.0-M3</version>
                     <configuration>
                         <rules>
                             <requireMavenVersion>
@@ -185,7 +185,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0-M5</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -197,7 +197,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -205,16 +205,16 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.8.1</version>
                     <configuration>
                         <generateBackupPoms>false</generateBackupPoms>
                     </configuration>
@@ -222,7 +222,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.14.1</version>
+                    <version>0.14.3</version>
                     <configuration>
                         <newVersion>
                             <file><path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path></file>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>6</version>
+        <version>7</version>
     </parent>
 
     <artifactId>digg</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,13 @@
                     <artifactId>japicmp-maven-plugin</artifactId>
                     <version>0.14.3</version>
                     <configuration>
+                        <oldVersion>
+                            <dependency>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${japicmp.oldversion}</version>
+                            </dependency>
+                        </oldVersion>
                         <newVersion>
                             <file><path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path></file>
                         </newVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>3.0</version>
+                    <version>4.0.rc2</version>
                     <configuration>
                         <header>src/main/license-header.txt</header>
                         <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -44,35 +44,40 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.0-RC1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.5.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.2-rc1</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.5.10</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.1-jre</version>
+            <version>29.0-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -84,7 +89,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.1.9</version>
+            <version>3.4.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -102,7 +107,7 @@
         <dependency>
             <groupId>com.mockrunner</groupId>
             <artifactId>mockrunner-jdbc</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.4</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -256,9 +261,6 @@
                         </goals>
                         <configuration>
                             <failOnWarning>true</failOnWarning>
-                            <usedDependencies>
-                                <usedDependency>org.junit.jupiter:junit-jupiter-engine</usedDependency>
-                            </usedDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggCollectors.java
+++ b/src/main/java/no/digipost/DiggCollectors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggCompare.java
+++ b/src/main/java/no/digipost/DiggCompare.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggConcurrent.java
+++ b/src/main/java/no/digipost/DiggConcurrent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggEnums.java
+++ b/src/main/java/no/digipost/DiggEnums.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggExceptions.java
+++ b/src/main/java/no/digipost/DiggExceptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggIO.java
+++ b/src/main/java/no/digipost/DiggIO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggMaps.java
+++ b/src/main/java/no/digipost/DiggMaps.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggOptionals.java
+++ b/src/main/java/no/digipost/DiggOptionals.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggPredicates.java
+++ b/src/main/java/no/digipost/DiggPredicates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/DiggStreams.java
+++ b/src/main/java/no/digipost/DiggStreams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/collection/BatchedIterable.java
+++ b/src/main/java/no/digipost/collection/BatchedIterable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/collection/ConflictingElementEncountered.java
+++ b/src/main/java/no/digipost/collection/ConflictingElementEncountered.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/collection/EnforceAtMostOneElementCollector.java
+++ b/src/main/java/no/digipost/collection/EnforceAtMostOneElementCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/collection/EnforceDistinctFirstTupleElementCollector.java
+++ b/src/main/java/no/digipost/collection/EnforceDistinctFirstTupleElementCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/collection/SimpleIterator.java
+++ b/src/main/java/no/digipost/collection/SimpleIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/concurrent/CompletionHandler.java
+++ b/src/main/java/no/digipost/concurrent/CompletionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/concurrent/OneTimeAssignment.java
+++ b/src/main/java/no/digipost/concurrent/OneTimeAssignment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/concurrent/OneTimeToggle.java
+++ b/src/main/java/no/digipost/concurrent/OneTimeToggle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/concurrent/SignalMediator.java
+++ b/src/main/java/no/digipost/concurrent/SignalMediator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/concurrent/TargetState.java
+++ b/src/main/java/no/digipost/concurrent/TargetState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/concurrent/Waiter.java
+++ b/src/main/java/no/digipost/concurrent/Waiter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/concurrent/executor/DefaultExecutors.java
+++ b/src/main/java/no/digipost/concurrent/executor/DefaultExecutors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/concurrent/executor/ExternallyManagedExecutorService.java
+++ b/src/main/java/no/digipost/concurrent/executor/ExternallyManagedExecutorService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/DecaFunction.java
+++ b/src/main/java/no/digipost/function/DecaFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/HexaFunction.java
+++ b/src/main/java/no/digipost/function/HexaFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/NonaFunction.java
+++ b/src/main/java/no/digipost/function/NonaFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/ObjIntFunction.java
+++ b/src/main/java/no/digipost/function/ObjIntFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/ObjLongFunction.java
+++ b/src/main/java/no/digipost/function/ObjLongFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/OctoFunction.java
+++ b/src/main/java/no/digipost/function/OctoFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/PentaFunction.java
+++ b/src/main/java/no/digipost/function/PentaFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/QuadFunction.java
+++ b/src/main/java/no/digipost/function/QuadFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/SeptiFunction.java
+++ b/src/main/java/no/digipost/function/SeptiFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/SerializableFunction.java
+++ b/src/main/java/no/digipost/function/SerializableFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/ThrowingBiConsumer.java
+++ b/src/main/java/no/digipost/function/ThrowingBiConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/ThrowingBiFunction.java
+++ b/src/main/java/no/digipost/function/ThrowingBiFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/ThrowingConsumer.java
+++ b/src/main/java/no/digipost/function/ThrowingConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/ThrowingFunction.java
+++ b/src/main/java/no/digipost/function/ThrowingFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/ThrowingRunnable.java
+++ b/src/main/java/no/digipost/function/ThrowingRunnable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/ThrowingSupplier.java
+++ b/src/main/java/no/digipost/function/ThrowingSupplier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/function/TriFunction.java
+++ b/src/main/java/no/digipost/function/TriFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/io/ConsumingInputStream.java
+++ b/src/main/java/no/digipost/io/ConsumingInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/io/DataSize.java
+++ b/src/main/java/no/digipost/io/DataSize.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/io/DataSizeUnit.java
+++ b/src/main/java/no/digipost/io/DataSizeUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/io/LimitedInputStream.java
+++ b/src/main/java/no/digipost/io/LimitedInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/io/Zip.java
+++ b/src/main/java/no/digipost/io/Zip.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/jdbc/AttributeMapper.java
+++ b/src/main/java/no/digipost/jdbc/AttributeMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/jdbc/AttributesRowMapper.java
+++ b/src/main/java/no/digipost/jdbc/AttributesRowMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/jdbc/BasicColumnMapper.java
+++ b/src/main/java/no/digipost/jdbc/BasicColumnMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/jdbc/ColumnMapper.java
+++ b/src/main/java/no/digipost/jdbc/ColumnMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/jdbc/Mappers.java
+++ b/src/main/java/no/digipost/jdbc/Mappers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/jdbc/NullableColumnMapper.java
+++ b/src/main/java/no/digipost/jdbc/NullableColumnMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/jdbc/RowMapper.java
+++ b/src/main/java/no/digipost/jdbc/RowMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/jdbc/SqlArray.java
+++ b/src/main/java/no/digipost/jdbc/SqlArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/text/Regex.java
+++ b/src/main/java/no/digipost/text/Regex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/time/ClockAdjuster.java
+++ b/src/main/java/no/digipost/time/ClockAdjuster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/time/ConditionalTimer.java
+++ b/src/main/java/no/digipost/time/ConditionalTimer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/time/ControllableClock.java
+++ b/src/main/java/no/digipost/time/ControllableClock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/time/JavaClockAccessors.java
+++ b/src/main/java/no/digipost/time/JavaClockAccessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/time/JavaClockAdditionalAccessors.java
+++ b/src/main/java/no/digipost/time/JavaClockAdditionalAccessors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/time/JavaClockAdjuster.java
+++ b/src/main/java/no/digipost/time/JavaClockAdjuster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/time/TimeSpan.java
+++ b/src/main/java/no/digipost/time/TimeSpan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Decuple.java
+++ b/src/main/java/no/digipost/tuple/Decuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Decuple.java
+++ b/src/main/java/no/digipost/tuple/Decuple.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.tuple;
 
+import no.digipost.function.DecaFunction;
+
 import java.util.function.Function;
 
 /**
@@ -237,5 +239,16 @@ public interface Decuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Viewab
      */
     @Override
     Decuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asDecuple();
+
+
+    /**
+     * Convert this decuple to an instance of an arbitrary type.
+     *
+     * @param <R> The type of the resulting instance
+     * @param convertor the function used to convert the contained
+     *                  values to a resulting compound instance.
+     * @return the result from the given function
+     */
+    <R> R to(DecaFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? super T10, R> convertor);
 
 }

--- a/src/main/java/no/digipost/tuple/Hextuple.java
+++ b/src/main/java/no/digipost/tuple/Hextuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Hextuple.java
+++ b/src/main/java/no/digipost/tuple/Hextuple.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.tuple;
 
+import no.digipost.function.HexaFunction;
+
 import java.util.function.Function;
 
 import static no.digipost.tuple.XTuple.TERMINATOR;
@@ -162,5 +164,16 @@ public interface Hextuple<T1, T2, T3, T4, T5, T6> extends ViewableAsHextuple<T1,
      */
     @Override
     Hextuple<T1, T2, T3, T4, T5, T6> asHextuple();
+
+
+    /**
+     * Convert this hextuple to an instance of an arbitrary type.
+     *
+     * @param <R> The type of the resulting instance
+     * @param convertor the function used to convert the contained
+     *                  values to a resulting compound instance.
+     * @return the result from the given function
+     */
+    <R> R to(HexaFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, R> convertor);
 
 }

--- a/src/main/java/no/digipost/tuple/Nonuple.java
+++ b/src/main/java/no/digipost/tuple/Nonuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Nonuple.java
+++ b/src/main/java/no/digipost/tuple/Nonuple.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.tuple;
 
+import no.digipost.function.NonaFunction;
+
 import java.util.function.Function;
 
 import static no.digipost.tuple.XTuple.TERMINATOR;
@@ -220,5 +222,16 @@ public interface Nonuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends ViewableAsN
      */
     @Override
     Nonuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> asNonuple();
+
+
+    /**
+     * Convert this nonuple to an instance of an arbitrary type.
+     *
+     * @param <R> The type of the resulting instance
+     * @param convertor the function used to convert the contained
+     *                  values to a resulting compound instance.
+     * @return the result from the given function
+     */
+    <R> R to(NonaFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, R> convertor);
 
 }

--- a/src/main/java/no/digipost/tuple/Octuple.java
+++ b/src/main/java/no/digipost/tuple/Octuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Octuple.java
+++ b/src/main/java/no/digipost/tuple/Octuple.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.tuple;
 
+import no.digipost.function.OctoFunction;
+
 import java.util.function.Function;
 
 import static no.digipost.tuple.XTuple.TERMINATOR;
@@ -201,5 +203,16 @@ public interface Octuple<T1, T2, T3, T4, T5, T6, T7, T8> extends ViewableAsOctup
      */
     @Override
     Octuple<T1, T2, T3, T4, T5, T6, T7, T8> asOctuple();
+
+
+    /**
+     * Convert this octuple to an instance of an arbitrary type.
+     *
+     * @param <R> The type of the resulting instance
+     * @param convertor the function used to convert the contained
+     *                  values to a resulting compound instance.
+     * @return the result from the given function
+     */
+    <R> R to(OctoFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, R> convertor);
 
 }

--- a/src/main/java/no/digipost/tuple/Pentuple.java
+++ b/src/main/java/no/digipost/tuple/Pentuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Pentuple.java
+++ b/src/main/java/no/digipost/tuple/Pentuple.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.tuple;
 
+import no.digipost.function.PentaFunction;
+
 import java.util.function.Function;
 
 import static no.digipost.tuple.XTuple.TERMINATOR;
@@ -143,5 +145,16 @@ public interface Pentuple<T1, T2, T3, T4, T5> extends ViewableAsPentuple<T1, T2,
      */
     @Override
     Pentuple<T1, T2, T3, T4, T5> asPentuple();
+
+
+    /**
+     * Convert this pentuple to an instance of an arbitrary type.
+     *
+     * @param <R> The type of the resulting instance
+     * @param convertor the function used to convert the contained
+     *                  values to a resulting compound instance.
+     * @return the result from the given function
+     */
+    <R> R to(PentaFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, R> convertor);
 
 }

--- a/src/main/java/no/digipost/tuple/Quadruple.java
+++ b/src/main/java/no/digipost/tuple/Quadruple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Quadruple.java
+++ b/src/main/java/no/digipost/tuple/Quadruple.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.tuple;
 
+import no.digipost.function.QuadFunction;
+
 import java.util.function.Function;
 
 import static no.digipost.tuple.XTuple.TERMINATOR;
@@ -124,5 +126,16 @@ public interface Quadruple<T1, T2, T3, T4> extends ViewableAsQuadruple<T1, T2, T
      */
     @Override
     Quadruple<T1, T2, T3, T4> asQuadruple();
+
+
+    /**
+     * Convert this quadruple to an instance of an arbitrary type.
+     *
+     * @param <R> The type of the resulting instance
+     * @param convertor the function used to convert the contained
+     *                  values to a resulting compound instance.
+     * @return the result from the given function
+     */
+    <R> R to(QuadFunction<? super T1, ? super T2, ? super T3, ? super T4, R> convertor);
 
 }

--- a/src/main/java/no/digipost/tuple/Septuple.java
+++ b/src/main/java/no/digipost/tuple/Septuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Septuple.java
+++ b/src/main/java/no/digipost/tuple/Septuple.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.tuple;
 
+import no.digipost.function.SeptiFunction;
+
 import java.util.function.Function;
 
 import static no.digipost.tuple.XTuple.TERMINATOR;
@@ -181,5 +183,16 @@ public interface Septuple<T1, T2, T3, T4, T5, T6, T7> extends ViewableAsSeptuple
      */
     @Override
     Septuple<T1, T2, T3, T4, T5, T6, T7> asSeptuple();
+
+
+    /**
+     * Convert this septuple to an instance of an arbitrary type.
+     *
+     * @param <R> The type of the resulting instance
+     * @param convertor the function used to convert the contained
+     *                  values to a resulting compound instance.
+     * @return the result from the given function
+     */
+    <R> R to(SeptiFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, R> convertor);
 
 }

--- a/src/main/java/no/digipost/tuple/Triple.java
+++ b/src/main/java/no/digipost/tuple/Triple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Triple.java
+++ b/src/main/java/no/digipost/tuple/Triple.java
@@ -15,6 +15,8 @@
  */
 package no.digipost.tuple;
 
+import no.digipost.function.TriFunction;
+
 import java.util.function.Function;
 
 import static no.digipost.tuple.XTuple.TERMINATOR;
@@ -105,4 +107,16 @@ public interface Triple<T1, T2, T3> extends ViewableAsTriple<T1, T2, T3> {
      */
     @Override
     Triple<T1, T2, T3> asTriple();
+
+
+    /**
+     * Convert this triple to an instance of an arbitrary type.
+     *
+     * @param <R> The type of the resulting instance
+     * @param convertor the function used to convert the contained
+     *                  values to a resulting compound instance.
+     * @return the result from the given function
+     */
+    <R> R to(TriFunction<? super T1, ? super T2, ? super T3, R> convertor);
+
 }

--- a/src/main/java/no/digipost/tuple/Tuple.java
+++ b/src/main/java/no/digipost/tuple/Tuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/Tuple.java
+++ b/src/main/java/no/digipost/tuple/Tuple.java
@@ -15,6 +15,7 @@
  */
 package no.digipost.tuple;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static no.digipost.tuple.XTuple.TERMINATOR;
@@ -92,5 +93,16 @@ public interface Tuple<T1, T2> extends ViewableAsTuple<T1, T2> {
      */
     @Override
     Tuple<T1, T2> asTuple();
+
+
+    /**
+     * Convert this tuple to an instance of an arbitrary type.
+     *
+     * @param <R> The type of the resulting instance
+     * @param convertor the function used to convert the contained
+     *                  values to a resulting compound instance.
+     * @return the result from the given function
+     */
+    <R> R to(BiFunction<? super T1, ? super T2, R> convertor);
 
 }

--- a/src/main/java/no/digipost/tuple/Tuple.java
+++ b/src/main/java/no/digipost/tuple/Tuple.java
@@ -15,6 +15,7 @@
  */
 package no.digipost.tuple;
 
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -31,6 +32,10 @@ import static no.digipost.tuple.XTuple.TERMINATOR;
  * @param <T2> The type of the second value
  */
 public interface Tuple<T1, T2> extends ViewableAsTuple<T1, T2> {
+
+    static <T1, T2> Tuple<T1, T2> ofMapEntry(Map.Entry<T1, T2> mapEntry) {
+        return of(mapEntry.getKey(), mapEntry.getValue());
+    }
 
     static <T1, T2> Tuple<T1, T2> of(T1 first, T2 second) {
         return new XTuple<>(first, second, TERMINATOR, null, null, null, null, null, null, null);

--- a/src/main/java/no/digipost/tuple/Tuples.java
+++ b/src/main/java/no/digipost/tuple/Tuples.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.tuple;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Utilies for working with tuples.
+ */
+public final class Tuples {
+
+    /**
+     * Convert a Java Collections {@link Map} to a Stream of {@link Tuple tuples}.
+     *
+     * @param <T1> The key type of the Map, becoming the type of the
+     *             {@link Tuple#first() first} tuple value.
+     * @param <T2> The value type of the Map, becoming the type of the
+     *             {@link Tuple#second() second} tuple value.
+     * @param map The map to convert.
+     *
+     * @return The resulting Stream of tuples.
+     */
+    public static final <T1, T2> Stream<Tuple<T1, T2>> ofMap(Map<T1, T2> map) {
+        return map.entrySet().stream().map(Tuple::ofMapEntry);
+    }
+
+    private Tuples() {
+    }
+}

--- a/src/main/java/no/digipost/tuple/ViewableAsDecuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsDecuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/ViewableAsHextuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsHextuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/ViewableAsNonuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsNonuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/ViewableAsOctuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsOctuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/ViewableAsPentuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsPentuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/ViewableAsQuadruple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsQuadruple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/ViewableAsSeptuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsSeptuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/ViewableAsTriple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsTriple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/ViewableAsTuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/XTuple.java
+++ b/src/main/java/no/digipost/tuple/XTuple.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/tuple/XTuple.java
+++ b/src/main/java/no/digipost/tuple/XTuple.java
@@ -15,9 +15,19 @@
  */
 package no.digipost.tuple;
 
+import no.digipost.function.DecaFunction;
+import no.digipost.function.HexaFunction;
+import no.digipost.function.NonaFunction;
+import no.digipost.function.OctoFunction;
+import no.digipost.function.PentaFunction;
+import no.digipost.function.QuadFunction;
+import no.digipost.function.SeptiFunction;
+import no.digipost.function.TriFunction;
+
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static java.util.function.Function.identity;
@@ -276,48 +286,93 @@ final class XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> implements Tuple<T1,
 
 
     @Override
-    public XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asDecuple() {
+    public Decuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asDecuple() {
         return this;
     }
 
     @Override
-    public XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asNonuple() {
+    public Nonuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> asNonuple() {
         return this;
     }
 
     @Override
-    public XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asOctuple() {
+    public Octuple<T1, T2, T3, T4, T5, T6, T7, T8> asOctuple() {
         return this;
     }
 
     @Override
-    public XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asSeptuple() {
+    public Septuple<T1, T2, T3, T4, T5, T6, T7> asSeptuple() {
         return this;
     }
 
     @Override
-    public XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asHextuple() {
+    public Hextuple<T1, T2, T3, T4, T5, T6> asHextuple() {
         return this;
     }
 
     @Override
-    public XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asPentuple() {
+    public Pentuple<T1, T2, T3, T4, T5> asPentuple() {
         return this;
     }
 
     @Override
-    public XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asQuadruple() {
+    public Quadruple<T1, T2, T3, T4> asQuadruple() {
         return this;
     }
 
     @Override
-    public XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asTriple() {
+    public Triple<T1, T2, T3> asTriple() {
         return this;
     }
 
     @Override
-    public XTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> asTuple() {
+    public Tuple<T1, T2> asTuple() {
         return this;
+    }
+
+    @Override
+    public <R> R to(BiFunction<? super T1, ? super T2, R> convertor) {
+        return convertor.apply(_1, _2);
+    }
+
+    @Override
+    public <R> R to(TriFunction<? super T1, ? super T2, ? super T3, R> convertor) {
+        return convertor.apply(_1, _2, _3);
+    }
+
+    @Override
+    public <R> R to(QuadFunction<? super T1, ? super T2, ? super T3, ? super T4, R> convertor) {
+        return convertor.apply(_1, _2, _3, _4);
+    }
+
+    @Override
+    public <R> R to(PentaFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, R> convertor) {
+        return convertor.apply(_1, _2, _3, _4, _5);
+    }
+
+    @Override
+    public <R> R to(HexaFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, R> convertor) {
+        return convertor.apply(_1, _2, _3, _4, _5, _6);
+    }
+
+    @Override
+    public <R> R to(SeptiFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, R> convertor) {
+        return convertor.apply(_1, _2, _3, _4, _5, _6, _7);
+    }
+
+    @Override
+    public <R> R to(OctoFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, R> convertor) {
+        return convertor.apply(_1, _2, _3, _4, _5, _6, _7, _8);
+    }
+
+    @Override
+    public <R> R to(NonaFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, R> convertor) {
+        return convertor.apply(_1, _2, _3, _4, _5, _6, _7, _8, _9);
+    }
+
+    @Override
+    public <R> R to(DecaFunction<? super T1, ? super T2, ? super T3, ? super T4, ? super T5, ? super T6, ? super T7, ? super T8, ? super T9, ? super T10, R> convertor) {
+        return convertor.apply(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10);
     }
 
 

--- a/src/main/java/no/digipost/util/Assignment.java
+++ b/src/main/java/no/digipost/util/Assignment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/AtMostOne.java
+++ b/src/main/java/no/digipost/util/AtMostOne.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/Attribute.java
+++ b/src/main/java/no/digipost/util/Attribute.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/AttributesMap.java
+++ b/src/main/java/no/digipost/util/AttributesMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/AttributesMap.java
+++ b/src/main/java/no/digipost/util/AttributesMap.java
@@ -15,7 +15,6 @@
  */
 package no.digipost.util;
 
-import no.digipost.tuple.Tuple;
 import no.digipost.tuple.ViewableAsTuple;
 
 import java.io.Serializable;
@@ -105,8 +104,7 @@ public final class AttributesMap implements Serializable {
          * @return the builder
          */
         public <V> Builder and(ViewableAsTuple<? extends SetsNamedValue<V>, V> attributeWithValue) {
-            Tuple<? extends SetsNamedValue<V>, V> t = attributeWithValue.asTuple();
-            return and(t.first(), t.second());
+            return attributeWithValue.asTuple().to(this::and);
         }
 
 

--- a/src/main/java/no/digipost/util/AutoCloseableAdapter.java
+++ b/src/main/java/no/digipost/util/AutoCloseableAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/AutoClosed.java
+++ b/src/main/java/no/digipost/util/AutoClosed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/ChainableAssignment.java
+++ b/src/main/java/no/digipost/util/ChainableAssignment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/GetsNamedValue.java
+++ b/src/main/java/no/digipost/util/GetsNamedValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/JustA.java
+++ b/src/main/java/no/digipost/util/JustA.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/JustALong.java
+++ b/src/main/java/no/digipost/util/JustALong.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/SetsNamedValue.java
+++ b/src/main/java/no/digipost/util/SetsNamedValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/ThrowingAutoClosed.java
+++ b/src/main/java/no/digipost/util/ThrowingAutoClosed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/util/ViewableAsOptional.java
+++ b/src/main/java/no/digipost/util/ViewableAsOptional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggBaseTest.java
+++ b/src/test/java/no/digipost/DiggBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggBaseTest.java
+++ b/src/test/java/no/digipost/DiggBaseTest.java
@@ -52,8 +52,8 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class DiggBaseTest implements WithQuickTheories {
 
@@ -131,7 +131,7 @@ public class DiggBaseTest implements WithQuickTheories {
         }
         MyResource resource = mock(MyResource.class);
         try (ThrowingAutoClosed<MyResource, RuntimeException> managedResource = throwingAutoClose(resource, MyResource::done)) {
-            verifyZeroInteractions(resource);
+            verifyNoInteractions(resource);
         }
         verify(resource, times(1)).done();
         verifyNoMoreInteractions(resource);
@@ -144,7 +144,7 @@ public class DiggBaseTest implements WithQuickTheories {
         }
         MyResource resource = mock(MyResource.class);
         try (ThrowingAutoClosed<MyResource, IOException> managedResource = throwingAutoClose(resource, MyResource::done)) {
-            verifyZeroInteractions(resource);
+            verifyNoInteractions(resource);
         }
         InOrder inOrder = inOrder(resource);
         inOrder.verify(resource, times(1)).done();
@@ -159,7 +159,7 @@ public class DiggBaseTest implements WithQuickTheories {
         }
         MyResource resource = mock(MyResource.class);
         try (AutoClosed<MyResource> managedResource = autoClose(resource, MyResource::done)) {
-            verifyZeroInteractions(resource);
+            verifyNoInteractions(resource);
         }
         verify(resource, times(1)).done();
         verifyNoMoreInteractions(resource);
@@ -177,7 +177,7 @@ public class DiggBaseTest implements WithQuickTheories {
             .when(closeable).close();
 
         Stream<Exception> closeExceptionsStream = close(generate(() -> closeable).limit(5).toArray(AutoCloseable[]::new));
-        verifyZeroInteractions(closeable);
+        verifyNoInteractions(closeable);
         List<Exception> closeExceptions = closeExceptionsStream.collect(toList());
         assertThat(closeExceptions, Matchers.contains(asList(instanceOf(IOException.class), instanceOf(IllegalStateException.class))));
         verify(closeable, times(5)).close();

--- a/src/test/java/no/digipost/DiggCollectorsTest.java
+++ b/src/test/java/no/digipost/DiggCollectorsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggCompareTest.java
+++ b/src/test/java/no/digipost/DiggCompareTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggEnumsTest.java
+++ b/src/test/java/no/digipost/DiggEnumsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggExceptionsTest.java
+++ b/src/test/java/no/digipost/DiggExceptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggIOTest.java
+++ b/src/test/java/no/digipost/DiggIOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggMapsTest.java
+++ b/src/test/java/no/digipost/DiggMapsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggOptionalsTest.java
+++ b/src/test/java/no/digipost/DiggOptionalsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggPredicatesTest.java
+++ b/src/test/java/no/digipost/DiggPredicatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/DiggStreamsTest.java
+++ b/src/test/java/no/digipost/DiggStreamsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/collection/BatchedIterableTest.java
+++ b/src/test/java/no/digipost/collection/BatchedIterableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/collection/SimpleIteratorTest.java
+++ b/src/test/java/no/digipost/collection/SimpleIteratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/concurrent/CompletionHandlerTest.java
+++ b/src/test/java/no/digipost/concurrent/CompletionHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/concurrent/OneTimeAssignmentTest.java
+++ b/src/test/java/no/digipost/concurrent/OneTimeAssignmentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/concurrent/OneTimeToggleTest.java
+++ b/src/test/java/no/digipost/concurrent/OneTimeToggleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/concurrent/SignalMediatorTest.java
+++ b/src/test/java/no/digipost/concurrent/SignalMediatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/concurrent/TargetStateTest.java
+++ b/src/test/java/no/digipost/concurrent/TargetStateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/function/ThrowingFunctionTest.java
+++ b/src/test/java/no/digipost/function/ThrowingFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/function/ThrowingRunnableTest.java
+++ b/src/test/java/no/digipost/function/ThrowingRunnableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/function/ThrowingSupplierTest.java
+++ b/src/test/java/no/digipost/function/ThrowingSupplierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/io/ConsumingInputStreamTest.java
+++ b/src/test/java/no/digipost/io/ConsumingInputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/io/DataSizeTest.java
+++ b/src/test/java/no/digipost/io/DataSizeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/io/LimitedInputStreamThrowingExceptionTest.java
+++ b/src/test/java/no/digipost/io/LimitedInputStreamThrowingExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/io/LimitedInputStreamYieldingEofTest.java
+++ b/src/test/java/no/digipost/io/LimitedInputStreamYieldingEofTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/io/SerializableClassesTest.java
+++ b/src/test/java/no/digipost/io/SerializableClassesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/jdbc/AttributesRowMapperTest.java
+++ b/src/test/java/no/digipost/jdbc/AttributesRowMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/jdbc/ColumnMapperTest.java
+++ b/src/test/java/no/digipost/jdbc/ColumnMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/jdbc/MappersTest.java
+++ b/src/test/java/no/digipost/jdbc/MappersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/jdbc/ResultSetMock.java
+++ b/src/test/java/no/digipost/jdbc/ResultSetMock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/jdbc/RowMapperTest.java
+++ b/src/test/java/no/digipost/jdbc/RowMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/text/RegexTest.java
+++ b/src/test/java/no/digipost/text/RegexTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/time/ConditionalTimerTest.java
+++ b/src/test/java/no/digipost/time/ConditionalTimerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/time/ControllableClockTest.java
+++ b/src/test/java/no/digipost/time/ControllableClockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/time/TimeSpanTest.java
+++ b/src/test/java/no/digipost/time/TimeSpanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/Compound.java
+++ b/src/test/java/no/digipost/tuple/Compound.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/Compound.java
+++ b/src/test/java/no/digipost/tuple/Compound.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.tuple;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+final class Compound {
+    final String text;
+    final int number;
+    final BigDecimal bigNumber;
+    final URI uri;
+    final String anotherText;
+    final UUID id;
+    final List<String> strings;
+    final int yetAnotherNumber;
+    final URI secondUri;
+    final Object arbitraryObject;
+
+    Compound(String text, int number) {
+        this(text, number, null, null, null, null, null, -1, null, null);
+    }
+
+    Compound(String text, int number, BigDecimal bigNumber) {
+        this(text, number, bigNumber, null, null, null, null, -1, null, null);
+    }
+
+    Compound(String text, int number, BigDecimal bigNumber, URI uri) {
+        this(text, number, bigNumber, uri, null, null, null, -1, null, null);
+    }
+
+    Compound(String text, int number, BigDecimal bigNumber, URI uri, String anotherText) {
+        this(text, number, bigNumber, uri, anotherText, null, null, -1, null, null);
+    }
+
+    Compound(String text, int number, BigDecimal bigNumber, URI uri, String anotherText, UUID id) {
+        this(text, number, bigNumber, uri, anotherText, id, null, -1, null, null);
+    }
+
+    Compound(String text, int number, BigDecimal bigNumber, URI uri, String anotherText, UUID id,
+            List<String> strings) {
+        this(text, number, bigNumber, uri, anotherText, id, strings, -1, null, null);
+    }
+
+    Compound(String text, int number, BigDecimal bigNumber, URI uri, String anotherText, UUID id,
+            List<String> strings, int yetAnotherNumber) {
+        this(text, number, bigNumber, uri, anotherText, id, strings, yetAnotherNumber, null, null);
+    }
+
+    Compound(String text, int number, BigDecimal bigNumber, URI uri, String anotherText, UUID id,
+            List<String> strings, int yetAnotherNumber, URI secondUri) {
+        this(text, number, bigNumber, uri, anotherText, id, strings, yetAnotherNumber, secondUri, null);
+    }
+
+    Compound(String text, int number, BigDecimal bigNumber, URI uri, String anotherText, UUID id,
+             List<String> strings, int yetAnotherNumber, URI secondUri, Object arbitraryObject) {
+        this.text = text;
+        this.number = number;
+        this.bigNumber = bigNumber;
+        this.uri = uri;
+        this.anotherText = anotherText;
+        this.id = id;
+        this.strings = strings;
+        this.yetAnotherNumber = yetAnotherNumber;
+        this.secondUri = secondUri;
+        this.arbitraryObject = arbitraryObject;
+    }
+}

--- a/src/test/java/no/digipost/tuple/DecupleTest.java
+++ b/src/test/java/no/digipost/tuple/DecupleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/HextupleTest.java
+++ b/src/test/java/no/digipost/tuple/HextupleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/NonupleTest.java
+++ b/src/test/java/no/digipost/tuple/NonupleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/OctupleTest.java
+++ b/src/test/java/no/digipost/tuple/OctupleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/PentupleTest.java
+++ b/src/test/java/no/digipost/tuple/PentupleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/QuadrupleTest.java
+++ b/src/test/java/no/digipost/tuple/QuadrupleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/SeptupleTest.java
+++ b/src/test/java/no/digipost/tuple/SeptupleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/TripleTest.java
+++ b/src/test/java/no/digipost/tuple/TripleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/TupleTest.java
+++ b/src/test/java/no/digipost/tuple/TupleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/TuplesTest.java
+++ b/src/test/java/no/digipost/tuple/TuplesTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.tuple;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static co.unruly.matchers.StreamMatchers.contains;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class TuplesTest {
+
+    @Test
+    void convertMapToTuples() {
+        Map<Integer, String> map = new HashMap<>();
+        map.put(1, "one");
+        map.put(2, "two");
+        assertThat(Tuples.ofMap(map), contains(Tuple.of(1, "one"), Tuple.of(2, "two")));
+    }
+
+}

--- a/src/test/java/no/digipost/tuple/XTupleTest.java
+++ b/src/test/java/no/digipost/tuple/XTupleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/tuple/XTupleTest.java
+++ b/src/test/java/no/digipost/tuple/XTupleTest.java
@@ -17,18 +17,62 @@ package no.digipost.tuple;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static java.math.BigDecimal.ONE;
+import static java.util.Arrays.asList;
 import static no.digipost.util.DiggMatchers.isEffectivelySerializable;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class XTupleTest {
+class XTupleTest {
     @Test
-    public void correctEqualsAndHashCode() {
+    void correctEqualsAndHashCode() {
         EqualsVerifier.forClass(XTuple.class).verify();
     }
 
     @Test
-    public void isSerializable() {
+    void isSerializable() {
         assertThat(new XTuple<>("x", 2, XTuple.TERMINATOR, null, null, null, null, null, null, null), isEffectivelySerializable());
+    }
+
+    @Test
+    void converting() {
+        XTuple<String, Integer, BigDecimal, URI, String, UUID, List<String>, Integer, URI, Long> xTuple =
+                new XTuple<>("x", 1, ONE, URI.create("my/resource"), "y", UUID.nameUUIDFromBytes("z".getBytes()), asList("a", "b"), 42, URI.create("."), 1L);
+
+        assertCorrectConversion(xTuple.asTuple().to(Compound::new), xTuple, Tuple.class);
+        assertCorrectConversion(xTuple.asTriple().to(Compound::new), xTuple, Triple.class);
+        assertCorrectConversion(xTuple.asQuadruple().to(Compound::new), xTuple, Quadruple.class);
+        assertCorrectConversion(xTuple.asPentuple().to(Compound::new), xTuple, Pentuple.class);
+        assertCorrectConversion(xTuple.asHextuple().to(Compound::new), xTuple, Hextuple.class);
+        assertCorrectConversion(xTuple.asSeptuple().to(Compound::new), xTuple, Septuple.class);
+        assertCorrectConversion(xTuple.asOctuple().to(Compound::new), xTuple, Octuple.class);
+        assertCorrectConversion(xTuple.asNonuple().to(Compound::new), xTuple, Nonuple.class);
+        assertCorrectConversion(xTuple.asDecuple().to(Compound::new), xTuple, Decuple.class);
+    }
+
+    private static void assertCorrectConversion(
+            Compound compound, XTuple<?, Integer, BigDecimal, URI, String, UUID, List<String>, Integer, URI, Long> xTuple, Class<?> tupleType) {
+
+        assertAll(Stream.<Executable>of(
+                () -> assertThat(compound.text, is(xTuple.first())),
+                () -> assertThat(compound.number, is(xTuple.second())),
+                () -> assertThat(compound.bigNumber, is(xTuple.third())),
+                () -> assertThat(compound.uri, is(xTuple.fourth())),
+                () -> assertThat(compound.anotherText, is(xTuple.fifth())),
+                () -> assertThat(compound.id, is(xTuple.sixth())),
+                () -> assertThat(compound.strings, is(xTuple.seventh())),
+                () -> assertThat(compound.yetAnotherNumber, is(xTuple.eighth())),
+                () -> assertThat(compound.secondUri, is(xTuple.ninth())),
+                () -> assertThat(compound.arbitraryObject, is(xTuple.tenth()))
+        ).limit(tupleType.getTypeParameters().length));
     }
 }

--- a/src/test/java/no/digipost/util/AtMostOneTest.java
+++ b/src/test/java/no/digipost/util/AtMostOneTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/util/AttributeTest.java
+++ b/src/test/java/no/digipost/util/AttributeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/util/AttributesMapTest.java
+++ b/src/test/java/no/digipost/util/AttributesMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/util/ChainableAssignmentTest.java
+++ b/src/test/java/no/digipost/util/ChainableAssignmentTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/util/DiggMatchers.java
+++ b/src/test/java/no/digipost/util/DiggMatchers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/util/EnforceAtMostOneElementCollectorTest.java
+++ b/src/test/java/no/digipost/util/EnforceAtMostOneElementCollectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/util/JustALongTest.java
+++ b/src/test/java/no/digipost/util/JustALongTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/util/JustAStringTest.java
+++ b/src/test/java/no/digipost/util/JustAStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
# New feature:

Add facility to convert tuples (triples, quadruples, etc) to arbitrary instances using either method references (typically a constructor `A::new`) having the same parameter type signature as the parameterized types of the tuple, or a lambda. Using a lambda enables arbitrary naming when referring to the constituents of the tuple, and a method reference offers a succinct conversion without needing to refer to internals of the tuple at all.

```java
Tuple tuple = Tuple.of("x", 1);

A a1 = tuple.to((text, num) -> new A(text, num));
// or:
A a2 = tuple.to(A::new);

// without convertor method:
A a3 = new A(tuple.first(), tuple.second())
```

As usual, the use of tuples should only be used by _particularly_ general code. Most often a custom class with fields offering more semantics of the values is in order.

To only view these changes, look at 921a2de


# Additional changes

All of the .java sources are touched because of a [change](https://github.com/mycila/license-maven-plugin/issues/118) in the license-maven-plugin, and can basically be ignored, as they all have this as their only diff:

```diff
- /**
+ /*
```

To get a head-start with the review, paste this script into devtools console, hit Enter, and it will mark all this noise as "viewed" and collapse these files.
```javascript
['no/digipost/Digg', 'no/digipost/collection', 'no/digipost/concurrent', 'no/digipost/function', 'no/digipost/io', 'no/digipost/jdbc', 'no/digipost/text', 'no/digipost/time', 'tuple/ViewableAs', 'no/digipost/util','/TupleTest','/TripleTest','/QuadrupleTest','/PentupleTest','/HextupleTest','/SeptupleTest','/OctupleTest','/NonupleTest','/DecupleTest'].forEach(fileName => document.querySelectorAll("div[data-path*='" + fileName + "'] input.js-reviewed-checkbox").forEach(viewedCheckbox => viewedCheckbox.click()))
```
