### PR TITLE
Max/min by property and Comparator using list of pre-ordered prioritized elements

### DIFF
--- a/src/main/java/no/digipost/DiggCompare.java
+++ b/src/main/java/no/digipost/DiggCompare.java
@@ -16,9 +16,11 @@
 package no.digipost;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 
+import static java.util.Arrays.asList;
 import static java.util.Comparator.comparing;
 
 
@@ -26,6 +28,7 @@ import static java.util.Comparator.comparing;
  * Utilities for comparing values.
  */
 public final class DiggCompare {
+
 
     /**
      * Choose the lesser of two {@link Comparable} objects.
@@ -39,6 +42,7 @@ public final class DiggCompare {
         return t1.compareTo(t2) > 0 ? t2 : t1;
     }
 
+
     /**
      * Choose the greater of two {@link Comparable} objects.
      * In the case where the objects are considered equal by
@@ -50,6 +54,7 @@ public final class DiggCompare {
     public static <T extends Comparable<T>> T max(T t1, T t2) {
         return t2.compareTo(t1) > 0 ? t2 : t1;
     }
+
 
     /**
      * Choose the lesser of two objects by using a given {@link Comparator}.
@@ -67,6 +72,7 @@ public final class DiggCompare {
     public static <T> T minBy(Comparator<? super T> propertyComparator, T t1, T t2) {
         return propertyComparator.compare(t1, t2) > 0 ? t2 : t1;
     }
+
 
     /**
      * Choose the lesser of two objects by comparing a
@@ -106,6 +112,7 @@ public final class DiggCompare {
         return comparator.compare(t2, t1) > 0 ? t2 : t1;
     }
 
+
     /**
      * Choose the greater of two objects by comparing a
      * {@link Comparable} value resolved from each object.
@@ -124,6 +131,53 @@ public final class DiggCompare {
      */
     public static <T, U extends Comparable<? super U>> T maxBy(Function<? super T, U> propertyExtractor, T t1, T t2) {
         return maxBy(comparing(propertyExtractor), t1, t2);
+    }
+
+
+    /**
+     * Create a comparator which will use a given list of already prioritized elements
+     * to determine the order of given elements. Two elements present in the prioritized list
+     * are compared according to their position in the list. An element not present in the
+     * elements is always considered lesser than a present element. Two elements not present
+     * are considered equal.
+     *
+     * @param elementsOrderedByPriority The elements which order is used to determine the order
+     *                                  of elements given to the comparator.
+     *
+     * @return the comparator
+     *
+     * @see #prioritize(List)
+     */
+    @SafeVarargs
+    public static <T> Comparator<T> prioritize(T ... elementsOrderedByPriority) {
+        return prioritize(asList(elementsOrderedByPriority));
+    }
+
+
+    /**
+     * Create a comparator which will use a given list of already prioritized elements
+     * to determine the order of given elements. Two elements present in the prioritized list
+     * are compared according to their position in the list. An element not present in the
+     * elements is always considered lesser than a present element. Two elements not present
+     * are considered equal.
+     *
+     * @param elementsOrderedByPriority The elements which order is used to determine the order
+     *                                  of elements given to the comparator.
+     *
+     * @return the comparator
+     */
+    public static <T> Comparator<T> prioritize(List<T> elementsOrderedByPriority) {
+        return (t1, t2) -> {
+            int firstIndex = elementsOrderedByPriority.indexOf(t1);
+            int secondIndex = elementsOrderedByPriority.indexOf(t2);
+            if (firstIndex < 0 && secondIndex >= 0) {
+                return 1;
+            } else if (secondIndex < 0 && firstIndex >= 0) {
+                return -1;
+            } else {
+                return Integer.compare(firstIndex, secondIndex);
+            }
+        };
     }
 
     private DiggCompare() {}

--- a/src/main/java/no/digipost/DiggCompare.java
+++ b/src/main/java/no/digipost/DiggCompare.java
@@ -15,14 +15,115 @@
  */
 package no.digipost;
 
+import java.util.Comparator;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+
+import static java.util.Comparator.comparing;
+
+
+/**
+ * Utilities for comparing values.
+ */
 public final class DiggCompare {
 
+    /**
+     * Choose the lesser of two {@link Comparable} objects.
+     * In the case where the objects are considered equal by
+     * {@link Comparable#compareTo(Object)}, the first argument
+     * is returned.
+     *
+     * @return the least of the two given objects.
+     */
     public static <T extends Comparable<T>> T min(T t1, T t2) {
         return t1.compareTo(t2) > 0 ? t2 : t1;
     }
 
+    /**
+     * Choose the greater of two {@link Comparable} objects.
+     * In the case where the objects are considered equal by
+     * {@link Comparable#compareTo(Object)}, the first argument
+     * is returned.
+     *
+     * @return the greatest of the two given objects.
+     */
     public static <T extends Comparable<T>> T max(T t1, T t2) {
         return t2.compareTo(t1) > 0 ? t2 : t1;
+    }
+
+    /**
+     * Choose the lesser of two objects by using a given {@link Comparator}.
+     *
+     * In the case where the objects are considered equal by
+     * {@link Comparable#compareTo(Object)}, the first argument
+     * is returned.
+     *
+     * <p>
+     * This is the static method equivalent of applying the resulting function from
+     * {@link BinaryOperator#minBy(Comparator)} with the given comparator as argument.
+     *
+     * @return the least of the two given objects.
+     */
+    public static <T> T minBy(Comparator<? super T> propertyComparator, T t1, T t2) {
+        return propertyComparator.compare(t1, t2) > 0 ? t2 : t1;
+    }
+
+    /**
+     * Choose the lesser of two objects by comparing a
+     * {@link Comparable} value resolved from each object.
+     *
+     * In the case where the objects are considered equal by
+     * {@link Comparable#compareTo(Object)}, the first argument
+     * is returned.
+     *
+     * <p>
+     * This is the static method equivalent of applying the resulting function from
+     * {@link BinaryOperator#minBy(Comparator)} with
+     * {@link Comparator#comparing(Function, Comparator) comparing(propertyExtractor)}
+     * as argument.
+     *
+     * @return the least of the two given objects.
+     */
+    public static <T, U extends Comparable<? super U>> T minBy(Function<? super T, U> propertyExtractor, T t1, T t2) {
+        return minBy(comparing(propertyExtractor), t1, t2);
+    }
+
+
+    /**
+     * Choose the greater of two objects by using a {@link Comparator}.
+     *
+     * In the case where the objects are considered equal by
+     * {@link Comparable#compareTo(Object)}, the first argument
+     * is returned.
+     *
+     * <p>
+     * This is the static method equivalent of applying the resulting function from
+     * {@link BinaryOperator#maxBy(Comparator)} with the given comparator as argument.
+     *
+     * @return the least of the two given objects.
+     */
+    public static <T> T maxBy(Comparator<? super T> comparator, T t1, T t2) {
+        return comparator.compare(t2, t1) > 0 ? t2 : t1;
+    }
+
+    /**
+     * Choose the greater of two objects by comparing a
+     * {@link Comparable} value resolved from each object.
+     *
+     * In the case where the objects are considered equal by
+     * {@link Comparable#compareTo(Object)}, the first argument
+     * is returned.
+     *
+     * <p>
+     * This is the static method equivalent of applying the resulting function from
+     * {@link BinaryOperator#maxBy(Comparator)} with
+     * {@link Comparator#comparing(Function) comparing(propertyExtractor)}
+     * as argument.
+     *
+     * @return the least of the two given objects.
+     */
+    public static <T, U extends Comparable<? super U>> T maxBy(Function<? super T, U> propertyExtractor, T t1, T t2) {
+        return maxBy(comparing(propertyExtractor), t1, t2);
     }
 
     private DiggCompare() {}

--- a/src/test/java/no/digipost/DiggCompareTest.java
+++ b/src/test/java/no/digipost/DiggCompareTest.java
@@ -20,11 +20,19 @@ import org.quicktheories.WithQuickTheories;
 import org.quicktheories.core.Gen;
 import org.quicktheories.dsl.TheoryBuilder2;
 
+import java.util.stream.Stream;
+
+import static co.unruly.matchers.StreamMatchers.contains;
+import static co.unruly.matchers.StreamMatchers.startsWith;
 import static java.util.Arrays.asList;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Stream.concat;
 import static no.digipost.DiggCompare.max;
 import static no.digipost.DiggCompare.maxBy;
 import static no.digipost.DiggCompare.min;
 import static no.digipost.DiggCompare.minBy;
+import static no.digipost.DiggCompare.prioritize;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.quicktheories.generators.Generate.pick;
 
 public class DiggCompareTest implements WithQuickTheories {
@@ -55,5 +63,23 @@ public class DiggCompareTest implements WithQuickTheories {
         forNonEqualsNums.check((x, y) -> minBy(Num::ordinal, x, y) == minBy(Num::ordinal, y, x));
         forNonEqualsNums.check((x, y) -> maxBy(Num::ordinal, x, y) == maxBy(Num::ordinal, y, x));
     }
+
+    @Test
+    void prioritizeCertainElements() {
+        assertThat(
+                Stream.of(Num.values()).sorted(prioritize(Num.SEVEN)),
+                startsWith(Num.SEVEN, Num.ZERO, Num.ONE, Num.TWO));
+
+        assertThat(
+                concat(Stream.of(Num.values()), Stream.of((Num) null))
+                    .sorted(prioritize(Num.SEVEN, null).thenComparing(prioritize(Num.FOUR).reversed())),
+                contains(Num.SEVEN, null, Num.ZERO, Num.ONE, Num.TWO, Num.THREE, Num.FIVE, Num.SIX, Num.EIGHT, Num.FOUR));
+
+        assertThat(
+                Stream.of(Num.values()).sorted(comparing(Num::ordinal, prioritize(7, 4))),
+                startsWith(Num.SEVEN, Num.FOUR, Num.ZERO, Num.ONE, Num.TWO));
+
+    }
+
 
 }

--- a/src/test/java/no/digipost/DiggCompareTest.java
+++ b/src/test/java/no/digipost/DiggCompareTest.java
@@ -17,10 +17,15 @@ package no.digipost;
 
 import org.junit.jupiter.api.Test;
 import org.quicktheories.WithQuickTheories;
+import org.quicktheories.core.Gen;
 import org.quicktheories.dsl.TheoryBuilder2;
 
+import static java.util.Arrays.asList;
 import static no.digipost.DiggCompare.max;
+import static no.digipost.DiggCompare.maxBy;
 import static no.digipost.DiggCompare.min;
+import static no.digipost.DiggCompare.minBy;
+import static org.quicktheories.generators.Generate.pick;
 
 public class DiggCompareTest implements WithQuickTheories {
 
@@ -34,4 +39,21 @@ public class DiggCompareTest implements WithQuickTheories {
         forNonEqualsInts.check((x, y) -> min(x, y) == min(y, x));
         forNonEqualsInts.check((x, y) -> max(x, y) == max(y, x));
     }
+
+    enum Num {
+        ZERO, ONE, TWO, THREE, FOUR, FIVE, SIX, SEVEN, EIGHT
+    }
+
+    @Test
+    void minAndMaxByProperty() {
+        Gen<Num> anyNum = pick(asList(Num.values()));
+        TheoryBuilder2<Num, Num> forNonEqualsNums = qt()
+                .forAll(anyNum, anyNum)
+                .assuming((x, y) -> !x.equals(y));
+
+        forNonEqualsNums.check((x, y) -> maxBy(Num::ordinal, x, y) != minBy(Num::ordinal, x, y));
+        forNonEqualsNums.check((x, y) -> minBy(Num::ordinal, x, y) == minBy(Num::ordinal, y, x));
+        forNonEqualsNums.check((x, y) -> maxBy(Num::ordinal, x, y) == maxBy(Num::ordinal, y, x));
+    }
+
 }


### PR DESCRIPTION
Some utilities to help constructing comparators.

`maxBy` and `minBy` are the method equivalents of constructing a [BinaryOperator](https://docs.oracle.com/javase/8/docs/api/java/util/function/BinaryOperator.html#minBy-java.util.Comparator-) with a comparator.

`prioritize` will create a Comparator which will give priority to elements according to a list of pre-ordered elements.