### PR TITLE
Allow freezing time to truncated current instant

### DIFF
--- a/src/main/java/no/digipost/time/ClockAdjuster.java
+++ b/src/main/java/no/digipost/time/ClockAdjuster.java
@@ -22,7 +22,9 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
 import java.util.function.UnaryOperator;
 
 /**
@@ -88,9 +90,21 @@ public interface ClockAdjuster {
 
 
     /**
-     * Signal that the clock should freeze at the instant it is currently at.
+     * Freeze the clock at its current instant in time.
      */
     void freeze();
+
+
+    /**
+     * Freeze the clock at its current instant in time, which will be truncated
+     * to the given unit.
+     *
+     * @param unit the unit the freezed instant will be truncated to
+     *
+     * @see ChronoUnit
+     * @see Instant#truncatedTo(TemporalUnit)
+     */
+    void freezeTruncatedTo(TemporalUnit unit);
 
 
     /**

--- a/src/main/java/no/digipost/time/JavaClockAdjuster.java
+++ b/src/main/java/no/digipost/time/JavaClockAdjuster.java
@@ -23,6 +23,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
 import java.util.function.UnaryOperator;
 
 /**
@@ -77,6 +78,11 @@ interface JavaClockAdjuster extends JavaClockAccessors, ClockAdjuster {
     @Override
     default void freeze() {
         freezeAt(instant(), getZone());
+    }
+
+    @Override
+    default void freezeTruncatedTo(TemporalUnit unit) {
+        freezeAt(instant().truncatedTo(unit), getZone());
     }
 
     @Override

--- a/src/test/java/no/digipost/time/ControllableClockTest.java
+++ b/src/test/java/no/digipost/time/ControllableClockTest.java
@@ -35,12 +35,15 @@ import java.util.List;
 import static co.unruly.matchers.Java8Matchers.where;
 import static java.time.Clock.systemUTC;
 import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.util.Arrays.asList;
 import static nl.jqno.equalsverifier.Warning.NULL_FIELDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -180,6 +183,21 @@ public class ControllableClockTest {
         }));
         assertThat(clock.instant().atZone(UTC), is(initialTime));
     }
+
+    @Test
+    void truncateInstantOfFreezedClock() {
+        Instant now = Instant.now().with(MILLI_OF_SECOND, 672);
+
+        ControllableClock clock = ControllableClock.freezedAt(now);
+        ZonedDateTime preciseTime = clock.zonedDateTime();
+        clock.freezeTruncatedTo(MINUTES);
+        ZonedDateTime truncatedTime = clock.zonedDateTime();
+        assertThat(truncatedTime, not(preciseTime));
+        assertThat(truncatedTime, where(ZonedDateTime::getSecond, is(0)));
+        assertThat(truncatedTime, where(ZonedDateTime::getNano, is(0)));
+        assertThat(truncatedTime, where(ZonedDateTime::getMinute, is(preciseTime.getMinute())));
+    }
+
 
 
 


### PR DESCRIPTION
It may be desirable to freeze a clock to a lesser precision than offered by the JDK, as the instant may be transformed and passed through facilities (e.g. databases) which needs to decrease the precision. This can make it more convenient
to use freezed clocks in tests which also employ precise evaluating of instances, but loss of precision is not relevant for regular freely running system clock. E.g. queries to pick out rows with timestamp before or after a given timestamp.