### PR TITLE
NonEmptyStream flatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _Digg_ is available in [![Maven Central Repository](https://maven-badges.herokua
 <dependency>
     <groupId>no.digipost</groupId>
     <artifactId>digg</artifactId>
-    <version>0.26</version>
+    <version>0.27</version>
 </dependency>
 ```
 

--- a/src/main/java/no/digipost/stream/NonEmptyStream.java
+++ b/src/main/java/no/digipost/stream/NonEmptyStream.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collector;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -79,6 +80,22 @@ public class NonEmptyStream<T> implements Stream<T> {
 
     public static <T> NonEmptyStream<T> of(Supplier<? extends T> firstElement, Stream<T> remainingElements) {
         return new NonEmptyStream<>(firstElement, remainingElements);
+    }
+
+    /**
+     * Create the same stream as produced by {@link Stream#iterate(Object, UnaryOperator)},
+     * but typed as {@link NonEmptyStream}.
+     *
+     * @param <T> the type of stream elements
+     * @param seed the initial element
+     * @param f a function to be applied to to the previous element to produce a new element
+     *
+     * @return the new infinite non-empty stream
+     *
+     * @see Stream#iterate(Object, UnaryOperator)
+     */
+    public static <T> NonEmptyStream<T> iterate(T seed, UnaryOperator<T> f) {
+        return new NonEmptyStream<>(Stream.iterate(seed, f));
     }
 
 
@@ -193,6 +210,23 @@ public class NonEmptyStream<T> implements Stream<T> {
     @Override
     public <R> Stream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
         return completeStream.flatMap(mapper);
+    }
+
+    /**
+     * Returns a stream consisting of the results of replacing each element of this stream with
+     * the contents of a mapped stream produced by applying the provided mapping function to each element.
+     * <p>
+     * This is an extension to the general {@link Stream} API, as flat-mapping to non-empty streams
+     * will preserve the non-empty guarantee of the stream.
+     *
+     * @param <R> The element type of the new stream
+     * @param mapper a non-interfering, stateless function to apply to each element which
+     *               produces a stream of new values
+     *
+     * @return the new non-empty stream
+     */
+    public <R> NonEmptyStream<R> flatMap(ToNonEmptyStreamFunction<? super T, ? extends R> mapper) {
+        return new NonEmptyStream<>(completeStream.flatMap(mapper));
     }
 
     @Override

--- a/src/main/java/no/digipost/stream/NonEmptyStream.java
+++ b/src/main/java/no/digipost/stream/NonEmptyStream.java
@@ -83,6 +83,65 @@ public class NonEmptyStream<T> implements Stream<T> {
     }
 
     /**
+     * Create a stream by concatenating a {@link NonEmptyStream}
+     * followed by a regular {@link Stream}, in the same manner as
+     * {@link Stream#concat(Stream, Stream)}. The resulting stream
+     * is also non-empty.
+     *
+     * @param <T> The type of stream elements
+     * @param a the first stream, non-empty
+     * @param b the second stream
+     *
+     * @return the concatenation of the two input streams
+     *
+     * @see Stream#concat(Stream, Stream)
+     */
+    public static <T> NonEmptyStream<T> concat(NonEmptyStream<? extends T> a, Stream<? extends T> b) {
+        return new NonEmptyStream<>(Stream.concat(a, b));
+    }
+
+    /**
+     * Create a stream by concatenating a regular {@link Stream}
+     * followed by a {@link NonEmptyStream}, in the same manner as
+     * {@link Stream#concat(Stream, Stream)}. The resulting stream
+     * is also non-empty.
+     *
+     * @param <T> The type of stream elements
+     * @param a the first stream
+     * @param b the second stream, non-empty
+     *
+     * @return the concatenation of the two input streams
+     *
+     * @see Stream#concat(Stream, Stream)
+     */
+    public static <T> NonEmptyStream<T> concat(Stream<? extends T> a, NonEmptyStream<? extends T> b) {
+        return new NonEmptyStream<>(Stream.concat(a, b));
+    }
+
+    /**
+     * Create a stream by concatenating two non-empty streams,
+     * in the same manner as {@link Stream#concat(Stream, Stream)}.
+     * The resulting stream is also non-empty.
+     * <p>
+     * This method overload is needed to avoid ambiguity with
+     * {@link #concat(NonEmptyStream, Stream)} and
+     * {@link #concat(Stream, NonEmptyStream)} when concatenating
+     * two non-empty streams.
+     *
+     * @param <T> The type of stream elements
+     * @param a the first non-empty stream
+     * @param b the second non-empty stream
+     *
+     * @return the concatenation of the two input streams
+     *
+     * @see Stream#concat(Stream, Stream)
+     */
+    public static <T> NonEmptyStream<T> concat(NonEmptyStream<? extends T> a, NonEmptyStream<? extends T> b) {
+        return new NonEmptyStream<>(Stream.concat(a, b));
+    }
+
+
+    /**
      * Create the same stream as produced by {@link Stream#iterate(Object, UnaryOperator)},
      * but typed as {@link NonEmptyStream}.
      *

--- a/src/main/java/no/digipost/stream/NonEmptyStream.java
+++ b/src/main/java/no/digipost/stream/NonEmptyStream.java
@@ -65,19 +65,57 @@ import static no.digipost.DiggBase.friendlyName;
  */
 public class NonEmptyStream<T> implements Stream<T> {
 
+    /**
+     * Create a non-empty stream containing a single element.
+     *
+     * @param <T> the type of the single element in the stream
+     * @param singleElement the element
+     *
+     * @return the new singleton non-empty stream
+     */
     public static <T> NonEmptyStream<T> of(T singleElement) {
         return of(singleElement, Stream.empty());
     }
 
+    /**
+     * Create a non-empty stream whose elements are the specified values.
+     *
+     * @param <T> the type of stream elements
+     * @param firstElement the first element
+     * @param remainingElements the remaining elements after the first
+     *
+     * @return the new non-empty stream
+     */
     @SafeVarargs
     public static <T> NonEmptyStream<T> of(T firstElement, T ... remainingElements) {
         return of(firstElement, Arrays.stream(remainingElements));
     }
 
+    /**
+     * Create a non-empty stream whose elements are a given first value,
+     * and remaining elements are provided from another stream.
+     *
+     * @param <T> the type of stream elements
+     * @param firstElement the first element
+     * @param remainingElements the remaining elements after the first
+     *
+     * @return the new non-empty stream
+     */
     public static <T> NonEmptyStream<T> of(T firstElement, Stream<T> remainingElements) {
         return of((Supplier<T>) () -> firstElement, remainingElements);
     }
 
+    /**
+     * Create a non-empty stream where the first element is resolved
+     * from a {@link Supplier}, and remaining elements are provided
+     * from another stream.
+     *
+     * @param <T> the type of stream elements
+     * @param firstElement the supplier of the first element
+     * @param remainingElements the remaining elements after the first
+     *
+     * @return the new non-empty stream
+     */
     public static <T> NonEmptyStream<T> of(Supplier<? extends T> firstElement, Stream<T> remainingElements) {
         return new NonEmptyStream<>(firstElement, remainingElements);
     }

--- a/src/main/java/no/digipost/stream/NonEmptyStream.java
+++ b/src/main/java/no/digipost/stream/NonEmptyStream.java
@@ -98,6 +98,21 @@ public class NonEmptyStream<T> implements Stream<T> {
         return new NonEmptyStream<>(Stream.iterate(seed, f));
     }
 
+    /**
+     * Create the same stream as produced by {@link Stream#generate(Supplier)},
+     * but typed as {@link NonEmptyStream}.
+     *
+     * @param <T> the type of stream elements
+     * @param s the {@code Supplier} of generated elements
+     *
+     * @return a new infinite non-empty stream
+     *
+     * @see Stream#generate(Supplier)
+     */
+    public static<T> NonEmptyStream<T> generate(Supplier<T> s) {
+        return new NonEmptyStream<>(Stream.generate(s));
+    }
+
 
     private final Stream<T> completeStream;
 

--- a/src/main/java/no/digipost/stream/ToNonEmptyStreamFunction.java
+++ b/src/main/java/no/digipost/stream/ToNonEmptyStreamFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.stream;
+
+import java.util.function.Function;
+
+/**
+ * Represents a function that accepts one argument and produces a {@link NonEmptyStream}.
+ *
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the elements in the resulting stream of the function
+ *
+ * @see Function
+ */
+@FunctionalInterface
+public interface ToNonEmptyStreamFunction<T, R> extends Function<T, NonEmptyStream<R>> {
+
+}

--- a/src/test/java/no/digipost/stream/NonEmptyStreamTest.java
+++ b/src/test/java/no/digipost/stream/NonEmptyStreamTest.java
@@ -72,6 +72,16 @@ public class NonEmptyStreamTest {
         assertThat(sum, is(10));
     }
 
+    @Test
+    void flatMapToNonEmptyStreams() {
+        int sumOfNumsAndTheirSquares = NonEmptyStream
+                .iterate(1, i -> i + 1)
+                .limitToNonEmpty(4)
+                .flatMap(i -> NonEmptyStream.of(i, i * i))
+                .reduceFromFirst(Math::addExact);
+
+        assertThat(sumOfNumsAndTheirSquares, is(40));
+    }
 
 
 }

--- a/src/test/java/no/digipost/stream/NonEmptyStreamTest.java
+++ b/src/test/java/no/digipost/stream/NonEmptyStreamTest.java
@@ -24,6 +24,8 @@ import static java.util.stream.Collectors.reducing;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static java.util.stream.Stream.iterate;
+import static no.digipost.DiggCollectors.toNonEmptyList;
+import static no.digipost.stream.NonEmptyStream.concat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -82,6 +84,16 @@ public class NonEmptyStreamTest {
 
         assertThat(sumOfNumsAndTheirSquares, is(40));
     }
+
+    @Test
+    void concatenateTwoStreams() {
+        assertThat(concat(NonEmptyStream.of("a"), NonEmptyStream.of("b")).collect(toNonEmptyList()), contains("a", "b"));
+        assertThat(concat(Stream.of("a"), NonEmptyStream.of("b")).collect(toNonEmptyList()), contains("a", "b"));
+        assertThat(concat(NonEmptyStream.of("a"), Stream.of("b")).collect(toNonEmptyList()), contains("a", "b"));
+    }
+
+
+
 
 
 }


### PR DESCRIPTION
Support for `NonEmptyStream.flatMap(T -> NonEmptyStream<R>)`.

Also add corresponding support for `concat`, `iterate`, and `generate` from `Stream`.