### PR TITLE
Fix NullPointerException in ThrowingSupplier

### DIFF
--- a/src/main/java/no/digipost/function/ThrowingSupplier.java
+++ b/src/main/java/no/digipost/function/ThrowingSupplier.java
@@ -31,7 +31,7 @@ public interface ThrowingSupplier<T, X extends Throwable> {
     }
 
     default Supplier<T> ifExceptionThrow(Function<? super Exception, ? extends RuntimeException> exceptionMapper) {
-        return () -> ifException(e -> { throw exceptionMapper.apply(e); }).get().get();
+        return () -> ifException(e -> { throw exceptionMapper.apply(e); }).get().orElse(null);
     }
 
     default Supplier<Optional<T>> ifException(Consumer<Exception> exceptionHandler) {

--- a/src/test/java/no/digipost/function/ThrowingSupplierTest.java
+++ b/src/test/java/no/digipost/function/ThrowingSupplierTest.java
@@ -31,14 +31,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.co.probablyfine.matchers.Java8Matchers.where;
 
-public class ThrowingSupplierTest {
+class ThrowingSupplierTest {
 
     private final RuntimeException ex = new RuntimeException();
 
     private final Error err = new Error();
 
     @Test
-    public void rethrowOriginalRuntimeException() {
+    void rethrowOriginalRuntimeException() {
         ThrowingSupplier<?, Exception> fn = () -> {throw ex;};
         assertThat(assertThrows(RuntimeException.class, fn.asUnchecked()::get), sameInstance(ex));
     }
@@ -49,14 +49,15 @@ public class ThrowingSupplierTest {
         assertThat(yieldsNull.asUnchecked(), where(Supplier::get, nullValue()));
     }
 
+
     @Test
-    public void rethrowOriginalError() {
+    void rethrowOriginalError() {
         ThrowingSupplier<?, Exception> fn = () -> {throw err;};
         assertThat(assertThrows(Error.class, fn.asUnchecked()::get), sameInstance(err));
     }
 
     @Test
-    public void translateToEmptyOptionalAndDelegateExceptionToHandler() {
+    void translateToEmptyOptionalAndDelegateExceptionToHandler() {
         ThrowingSupplier<?, Exception> fn = () -> {throw ex;};
         @SuppressWarnings("unchecked")
         Consumer<Exception> handler = mock(Consumer.class);
@@ -64,4 +65,5 @@ public class ThrowingSupplierTest {
         assertThat(fn.ifException(handler).get(), is(empty()));
         verify(handler, times(1)).accept(ex);
     }
+
 }

--- a/src/test/java/no/digipost/function/ThrowingSupplierTest.java
+++ b/src/test/java/no/digipost/function/ThrowingSupplierTest.java
@@ -18,15 +18,18 @@ package no.digipost.function;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static java.util.Optional.empty;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 
 public class ThrowingSupplierTest {
 
@@ -38,6 +41,12 @@ public class ThrowingSupplierTest {
     public void rethrowOriginalRuntimeException() {
         ThrowingSupplier<?, Exception> fn = () -> {throw ex;};
         assertThat(assertThrows(RuntimeException.class, fn.asUnchecked()::get), sameInstance(ex));
+    }
+
+    @Test
+    void allowsNull() {
+        ThrowingSupplier<?, Exception> yieldsNull = () -> null;
+        assertThat(yieldsNull.asUnchecked(), where(Supplier::get, nullValue()));
     }
 
     @Test


### PR DESCRIPTION
Replaces unsafe call to `Optional.get()` with `.orElse(null)`.