### PR TITLE
Add more constructors for NonEmptyList

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _Digg_ is available in [![Maven Central Repository](https://maven-badges.herokua
 <dependency>
     <groupId>no.digipost</groupId>
     <artifactId>digg</artifactId>
-    <version>0.28</version>
+    <version>0.30</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Javadocs are available at [javadoc.io/doc/no.digipost/digg](https://www.javadoc.
 
 ## Non-empty lists and streams
 
-Many actual domains deal with one to many elements. While using the general case of e.g. a `List` to model this works all fine, it would be even better to have the type system to eliminate the illegal state of zero elements as early as possible, and in many cases also to offer some operations which are guarantied to be safe having one or more elements.
+Many actual domains deal with cardinalities of one to many instead of zero to many. That is, having zero elements of something has no meaning in the domain; it would be an illegal state. While using the general case of e.g. a `List` to model this may work fine, it would be even better to have the type system to eliminate the illegal state of zero elements as early as possible, and in many cases also to offer some operations which are guarantied to be safe having one or more elements.
 
 _Digg_ contains some extensions of the Java Collections and Streams API to provide first-class support for multitudes of elements which are _not_ empty: `NonEmptyList` and `NonEmptyStream`. Both these types are fully compatible with code already processing JDK lists and/or streams.
 
@@ -62,7 +62,7 @@ List<String> list = NonEmptyList.of(1, 2, 3).stream()
 It is possible to preserve the non-emptyness going from list to stream, and back to list, on a type level, using a particular collector for `NonEmptyList`, found in the `DiggCollectors` class:
 
 ```java
-NonEmptyList list = NonEmptyList.of(1, 2, 3).stream()
+NonEmptyList<String> list = NonEmptyList.of(1, 2, 3).stream()
         .map(String::valueOf)
         .collect(toNonEmptyList()); //static imported from DiggCollectors
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.9.0</version>
+            <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.6</version>
+            <version>3.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/no/digipost/collection/NonEmptyList.java
+++ b/src/main/java/no/digipost/collection/NonEmptyList.java
@@ -145,15 +145,15 @@ public interface NonEmptyList<E> extends List<E> {
      * more flexibility in handling of a possible empty list.
      *
      * @param <E> the type of elements in the list.
-     * @param list the list, which may be empty
+     * @param nonEmptyList the list, which is assumed not to be empty
      *
      * @return the resulting non-empty list, or {@link Optional#empty()} if the
      *         given list is empty
      *
      * @throws IllegalArgumentException if the given list is empty
      */
-    static <E> NonEmptyList<E> ofUnsafe(List<E> list) {
-        return of(list).orElseThrow(() -> new IllegalArgumentException("empty list"));
+    static <E> NonEmptyList<E> ofUnsafe(List<E> nonEmptyList) {
+        return of(nonEmptyList).orElseThrow(() -> new IllegalArgumentException("empty list"));
     }
 
 
@@ -166,15 +166,15 @@ public interface NonEmptyList<E> extends List<E> {
      * more flexibility in handling of a possible empty list.
      *
      * @param <E> the type of elements in the array.
-     * @param array the array, which may be empty
+     * @param nonEmptyArray the array, which is assumed not to be empty
      *
      * @return the resulting non-empty list, or {@link Optional#empty()} if the
      *         given array is empty
      *
      * @throws IllegalArgumentException if the given array is empty
      */
-    static <E> NonEmptyList<E> ofUnsafe(E[] array) {
-        return of(array).orElseThrow(() -> new IllegalArgumentException("empty array"));
+    static <E> NonEmptyList<E> ofUnsafe(E[] nonEmptyArray) {
+        return of(nonEmptyArray).orElseThrow(() -> new IllegalArgumentException("empty array"));
     }
 
 
@@ -218,7 +218,7 @@ public interface NonEmptyList<E> extends List<E> {
      * more flexibility in handling of a possible empty list.
      *
      * @param <E> the type of elements in the list.
-     * @param nonEmptyList the list
+     * @param nonEmptyList the list, which is assumed not to be empty
      *
      * @return the resulting non-empty list
      *
@@ -241,7 +241,7 @@ public interface NonEmptyList<E> extends List<E> {
      * more flexibility in handling of a possible empty array.
      *
      * @param <E> the type of elements in the array.
-     * @param array the array
+     * @param nonEmptyArray the array, which is assumed not to be empty
      *
      * @return the resulting non-empty list
      *
@@ -249,8 +249,8 @@ public interface NonEmptyList<E> extends List<E> {
      *
      * @see #copyOf(Object[])
      */
-    static <E> NonEmptyList<E> copyOfUnsafe(E[] array) {
-        return copyOf(array).orElseThrow(() -> new IllegalArgumentException("empty array"));
+    static <E> NonEmptyList<E> copyOfUnsafe(E[] nonEmptyArray) {
+        return copyOf(nonEmptyArray).orElseThrow(() -> new IllegalArgumentException("empty array"));
     }
 
 

--- a/src/main/java/no/digipost/collection/NonEmptyList.java
+++ b/src/main/java/no/digipost/collection/NonEmptyList.java
@@ -109,24 +109,58 @@ public interface NonEmptyList<E> extends List<E> {
 
 
     /**
-     * <strong>Unsafe</strong> construction of non-empty list from a possibly empty list.
+     * Try to construct a non-empty list from a given array, which may be empty.
+     *
+     * @param <E> the type of elements in the array.
+     * @param array the array, which may be empty
+     *
+     * @return the resulting non-empty list, or {@link Optional#empty()} if the
+     *         given array is empty
+     */
+    static <E> Optional<NonEmptyList<E>> of(E[] array) {
+        return of(asList(array));
+    }
+
+
+    /**
+     * Try to construct a non-empty list from a given list, which is assumed is not empty.
      * <p>
      * This method should only be used when the given list is <em>guarantied</em>
      * to be empty, and thus offers a fail-fast way to introduce the non-empty
-     * quality on a type level. Use {@link #copyOf(List)} if you need
+     * quality on a type level. Use {@link #of(List)} if you need
      * more flexibility in handling of a possible empty list.
      *
      * @param <E> the type of elements in the list.
-     * @param list the list
+     * @param list the list, which may be empty
      *
-     * @return the resulting non-empty list
+     * @return the resulting non-empty list, or {@link Optional#empty()} if the
+     *         given list is empty
      *
      * @throws IllegalArgumentException if the given list is empty
-     *
-     * @see #copyOf(List)
      */
     static <E> NonEmptyList<E> ofUnsafe(List<E> list) {
-        return copyOf(list).orElseThrow(() -> new IllegalArgumentException("empty list"));
+        return of(list).orElseThrow(() -> new IllegalArgumentException("empty list"));
+    }
+
+
+    /**
+     * Try to construct a non-empty list from a given array, which is assumed is not empty.
+     * <p>
+     * This method should only be used when the given list is <em>guarantied</em>
+     * to be empty, and thus offers a fail-fast way to introduce the non-empty
+     * quality on a type level. Use {@link #of(Object[])} if you need
+     * more flexibility in handling of a possible empty list.
+     *
+     * @param <E> the type of elements in the array.
+     * @param array the array, which may be empty
+     *
+     * @return the resulting non-empty list, or {@link Optional#empty()} if the
+     *         given array is empty
+     *
+     * @throws IllegalArgumentException if the given array is empty
+     */
+    static <E> NonEmptyList<E> ofUnsafe(E[] array) {
+        return of(array).orElseThrow(() -> new IllegalArgumentException("empty array"));
     }
 
 
@@ -146,8 +180,23 @@ public interface NonEmptyList<E> extends List<E> {
 
 
     /**
+     * Try to construct a non-empty list from copying the elements
+     * of a given array, which may be empty.
+     *
+     * @param <E> the type of elements in the array.
+     * @param array the array, which may be empty
+     *
+     * @return the resulting non-empty list,
+     *         or {@link Optional#empty()} if the given array is empty
+     */
+    static <E> Optional<NonEmptyList<E>> copyOf(E[] array) {
+        return copyOf(asList(array));
+    }
+
+
+    /**
      * <strong>Unsafe</strong> construction of non-empty list from copying the
-     * elements of a possibly empty list.
+     * elements of a list assumed to be non-empty.
      * <p>
      * This method should only be used when the given list is <em>guarantied</em>
      * to be empty, and thus offers a fail-fast way to introduce the non-empty
@@ -165,6 +214,29 @@ public interface NonEmptyList<E> extends List<E> {
      */
     static <E> NonEmptyList<E> copyOfUnsafe(List<E> nonEmptyList) {
         return copyOf(nonEmptyList).orElseThrow(() -> new IllegalArgumentException("empty list"));
+    }
+
+
+    /**
+     * <strong>Unsafe</strong> construction of non-empty list from copying the
+     * elements of an array assumed to be non-empty.
+     * <p>
+     * This method should only be used when the given array is <em>guarantied</em>
+     * to be empty, and thus offers a fail-fast way to introduce the non-empty
+     * quality on a type level. Use {@link #copyOf(Object[])} if you need
+     * more flexibility in handling of a possible empty array.
+     *
+     * @param <E> the type of elements in the array.
+     * @param array the array
+     *
+     * @return the resulting non-empty list
+     *
+     * @throws IllegalArgumentException if the given array is empty
+     *
+     * @see #copyOf(Object[])
+     */
+    static <E> NonEmptyList<E> copyOfUnsafe(E[] array) {
+        return copyOf(array).orElseThrow(() -> new IllegalArgumentException("empty array"));
     }
 
 

--- a/src/main/java/no/digipost/collection/NonEmptyList.java
+++ b/src/main/java/no/digipost/collection/NonEmptyList.java
@@ -235,7 +235,7 @@ public interface NonEmptyList<E> extends List<E> {
      * <strong>Unsafe</strong> construction of non-empty list from copying the
      * elements of an array assumed to be non-empty.
      * <p>
-     * This method should only be used when the given array is <em>guarantied</em>
+     * This method should only be used when the given array is <em>guaranteed</em>
      * to be empty, and thus offers a fail-fast way to introduce the non-empty
      * quality on a type level. Use {@link #copyOf(Object[])} if you need
      * more flexibility in handling of a possible empty array.

--- a/src/main/java/no/digipost/collection/NonEmptyList.java
+++ b/src/main/java/no/digipost/collection/NonEmptyList.java
@@ -28,6 +28,20 @@ import static java.util.Arrays.asList;
  * take care to ensure that instances will <em>never</em> in any
  * circumstance be allowed to be empty.
  *
+ * @implNote In general, constructing a {@code NonEmptyList} from another
+ * mutable container source (e.g. an existing list or array), and then changing the
+ * contents of the source, results in undefined behavior of the non-empty list. The
+ * only guarantee is that the non-empty list will <em>never</em> be empty, but the
+ * behavior when mutating a list on which the non-empty list is based on should not be
+ * relied on.
+ * <p>
+ * If you need to construct non-empty lists based on another container you
+ * need to further mutate, consider using one of the {@link #copyOf(List) copyOf}
+ * constructors, which will copy the given references so that any subsequent changes to the
+ * to the given source container will not be reflected in the created non-empty list. (As usual,
+ * this is a shallow copy, meaning that the instances themselves can of course be mutated by anything.)
+ *
+ *
  * @param <E> the type of elements in this list
  */
 public interface NonEmptyList<E> extends List<E> {

--- a/src/test/java/no/digipost/collection/NonEmptyListTest.java
+++ b/src/test/java/no/digipost/collection/NonEmptyListTest.java
@@ -15,17 +15,29 @@
  */
 package no.digipost.collection;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.co.probablyfine.matchers.OptionalMatchers;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static no.digipost.DiggCollectors.toNonEmptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.integers;
 import static org.quicktheories.generators.SourceDSL.lists;
@@ -70,6 +82,65 @@ public class NonEmptyListTest {
             .checkAssert(list -> assertThat(list, whereNot(NonEmptyList::isEmpty)));
 
         assertThat(NonEmptyList.of(emptyList()), is(Optional.empty()));
+    }
+
+    @Nested
+    class Construction {
+        @Test
+        void unsafeThrowsIfEmpty() {
+            assertThrows(IllegalArgumentException.class, () -> NonEmptyList.ofUnsafe(new Object[0]));
+            assertThrows(IllegalArgumentException.class, () -> NonEmptyList.ofUnsafe(emptyList()));
+            assertThrows(IllegalArgumentException.class, () -> NonEmptyList.copyOfUnsafe(new Object[0]));
+            assertThrows(IllegalArgumentException.class, () -> NonEmptyList.copyOfUnsafe(emptyList()));
+        }
+
+        @Test
+        void copyConstructorsAreNotAffectedByChangesInSource() {
+            NonEmptyList<Character> copyOfArray = constructAndMutateSourceArray(source -> NonEmptyList.copyOf(source).get(), 'a', 'b', 'c');
+            assertThat(copyOfArray, contains('a', 'b', 'c'));
+            NonEmptyList<Character> copyOfList = constructAndMutateSourceList(source -> NonEmptyList.copyOf(source).get(), 'a', 'b', 'c');
+            assertThat(copyOfList, contains('a', 'b', 'c'));
+            NonEmptyList<Character> copyOfArrayUnsafe = constructAndMutateSourceArray(NonEmptyList::copyOfUnsafe, 'a', 'b', 'c');
+            assertThat(copyOfArrayUnsafe, contains('a', 'b', 'c'));
+            NonEmptyList<Character> copyOfListUnsafe = constructAndMutateSourceList(NonEmptyList::copyOfUnsafe, 'a', 'b', 'c');
+            assertThat(copyOfListUnsafe, contains('a', 'b', 'c'));
+        }
+
+        @Test
+        void changesInSourceWillMutateListsFromNonCopyingConstructors() {
+            NonEmptyList<Character> viewOfMutatedArray = constructAndMutateSourceArray(source -> NonEmptyList.of(source).get(), 'a', 'b', 'c');
+            assertThat(viewOfMutatedArray, not(contains('a', 'b', 'c')));
+            NonEmptyList<Character> viewOfMutatedList = constructAndMutateSourceList(source -> NonEmptyList.of(source).get(), 'a', 'b', 'c');
+            assertThat(viewOfMutatedList, not(contains('a', 'b', 'c')));
+            NonEmptyList<Character> viewOfMutatedArrayUnsafe = constructAndMutateSourceArray(NonEmptyList::ofUnsafe, 'a', 'b', 'c');
+            assertThat(viewOfMutatedArrayUnsafe, not(contains('a', 'b', 'c')));
+            NonEmptyList<Character> viewOfMutatedListUnsafe = constructAndMutateSourceList(NonEmptyList::ofUnsafe, 'a', 'b', 'c');
+            assertThat(viewOfMutatedListUnsafe, not(contains('a', 'b', 'c')));
+        }
+
+
+        private NonEmptyList<Character> constructAndMutateSourceArray(Function<Character[], NonEmptyList<Character>> listConstructor, Character ... chars) {
+            Character[] sourceArray = Arrays.copyOf(chars, chars.length);
+            NonEmptyList<Character> nonEmptyList = listConstructor.apply(sourceArray);
+            assertThat(nonEmptyList, contains(chars));
+            for (int i = 0; i < sourceArray.length; i++) {
+                sourceArray[i] = (char) (sourceArray[i] + sourceArray.length);
+            }
+            assertAll(Stream.of(chars).map(c -> () -> assertThat(sourceArray, not(hasItemInArray(c)))));
+            return nonEmptyList;
+        }
+
+        private NonEmptyList<Character> constructAndMutateSourceList(Function<List<Character>, NonEmptyList<Character>> listConstructor, Character ... chars) {
+            List<Character> sourceList = new ArrayList<>(asList(chars));
+            NonEmptyList<Character> nonEmptyList = listConstructor.apply(sourceList);
+            assertThat(nonEmptyList, contains(chars));
+            for (int i = 0; i < sourceList.size(); i++) {
+                sourceList.set(i, (char) (sourceList.get(i) + sourceList.size()));
+            }
+            assertAll(Stream.of(chars).map(c -> () -> assertThat(sourceList, not(hasItem(c)))));
+            return nonEmptyList;
+        }
+
     }
 
 }


### PR DESCRIPTION
More complete set of constructors from both lists and arrays. The constructors are named consistently whether they copy the element references of the source or not.

Interestingly, japicmp reports adding new _static_ methods to an interface as a binary incompatible change, but I suspect this is a false positive, since it's identified as `METHOD_NEW_DEFAULT`, and a static methods is not the same as a default method. I have asked about this here: https://github.com/siom79/japicmp/issues/289