### PR TITLE
DiggExceptions.asUnchecked(..) enhancements

### DIFF
--- a/src/main/java/no/digipost/DiggExceptions.java
+++ b/src/main/java/no/digipost/DiggExceptions.java
@@ -22,6 +22,8 @@ import no.digipost.function.ThrowingFunction;
 import no.digipost.function.ThrowingRunnable;
 import no.digipost.function.ThrowingSupplier;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -102,7 +104,11 @@ public final class DiggExceptions {
      *         and the given exception as its {@link Throwable#getCause() cause}
      */
     public static RuntimeException asUnchecked(Throwable t, String message) {
-        return new RuntimeException(message, t);
+        if (t instanceof IOException) {
+            return new UncheckedIOException(message, (IOException) t);
+        } else {
+            return new RuntimeException(message, t);
+        }
     }
 
     /**

--- a/src/main/java/no/digipost/DiggExceptions.java
+++ b/src/main/java/no/digipost/DiggExceptions.java
@@ -15,11 +15,18 @@
  */
 package no.digipost;
 
-import no.digipost.function.*;
+import no.digipost.function.ThrowingBiConsumer;
+import no.digipost.function.ThrowingBiFunction;
+import no.digipost.function.ThrowingConsumer;
+import no.digipost.function.ThrowingFunction;
+import no.digipost.function.ThrowingRunnable;
+import no.digipost.function.ThrowingSupplier;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import static no.digipost.DiggBase.friendlyName;
 
 public final class DiggExceptions {
 
@@ -35,16 +42,67 @@ public final class DiggExceptions {
         return causes.build();
     }
 
+    /**
+     * Generate a concise description of an exception/throwable
+     * containing the {@link DiggBase#friendlyName(Class) "friendly name"}
+     * of the exception's type, and its {@link Throwable#getMessage() message}.
+     *
+     * @param t the exception/throwable
+     *
+     * @return the description
+     */
     public static String exceptionNameAndMessage(Throwable t) {
-        return t.getClass().getSimpleName() + ": '" + t.getMessage() + "'";
+        return friendlyName(t.getClass()) + ": '" + t.getMessage() + "'";
     }
 
+
+    /**
+     * Utility for acquiring a {@link RuntimeException} from any {@link Throwable}.
+     * This method is appropriate to use when you have caught an exception which you have no
+     * ability to handle, and you need to just throw it from a context where you are
+     * not allowed to.
+     * <p>
+     * If you want to add more context to the thrown exception (which you probably should), consider
+     * using {@link #asUnchecked(Throwable, String)} or {@link #asUnchecked(Throwable, Function)}.
+     *
+     * @param t the exception (Throwable)
+     *
+     * @return a new {@link RuntimeException} which has the given exception as its {@link Throwable#getCause() cause},
+     *         or {@code t} itself casted to {@code RuntimeException} if possible
+     */
     public static RuntimeException asUnchecked(Throwable t) {
-        return asUnchecked(t, DiggExceptions::exceptionNameAndMessage);
+        return t instanceof RuntimeException ? (RuntimeException) t : asUnchecked(t, DiggExceptions::exceptionNameAndMessage);
     }
 
-    public static <X extends Throwable> RuntimeException asUnchecked(X t, Function<? super X, String> message) {
-        return t instanceof RuntimeException ? (RuntimeException) t : new RuntimeException(message.apply(t), t);
+
+    /**
+     * Utility for acquiring a {@link RuntimeException} with a custom message from any {@link Throwable}.
+     * The result from this method will <em>always</em> be a new exception instance.
+     *
+     * @param <X> the type of the given exception
+     * @param t the exception (Throwable)
+     * @param messageCreator a function which returns the message for the new exception
+     *
+     * @return a new {@link RuntimeException} which has the result from the {@code messageCreator} function as its
+     *         {@link Throwable#getMessage() message}, and the given exception as its {@link Throwable#getCause() cause}
+     */
+    public static <X extends Throwable> RuntimeException asUnchecked(X t, Function<? super X, String> messageCreator) {
+        return asUnchecked(t, messageCreator.apply(t));
+    }
+
+
+    /**
+     * Utility for acquiring a {@link RuntimeException} with a custom message from any {@link Throwable}.
+     * The result from this method will <em>always</em> be a new exception instance.
+     *
+     * @param t the exception (Throwable)
+     * @param message the message for the new exception
+     *
+     * @return a new {@link RuntimeException} which has the given {@code message},
+     *         and the given exception as its {@link Throwable#getCause() cause}
+     */
+    public static RuntimeException asUnchecked(Throwable t, String message) {
+        return new RuntimeException(message, t);
     }
 
     /**

--- a/src/test/java/no/digipost/DiggExceptionsTest.java
+++ b/src/test/java/no/digipost/DiggExceptionsTest.java
@@ -16,6 +16,7 @@
 package no.digipost;
 
 import no.digipost.concurrent.OneTimeToggle;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -23,23 +24,26 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static java.util.stream.Collectors.toList;
 import static no.digipost.DiggExceptions.applyUnchecked;
+import static no.digipost.DiggExceptions.asUnchecked;
 import static no.digipost.DiggExceptions.causalChainOf;
 import static no.digipost.DiggExceptions.getUnchecked;
 import static no.digipost.DiggExceptions.mayThrow;
 import static no.digipost.DiggExceptions.runUnchecked;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 
 public class DiggExceptionsTest {
 
@@ -98,6 +102,28 @@ public class DiggExceptionsTest {
     }
 
 
+    @Nested
+    class AsUnchecked {
 
+        @Test
+        void castToUnchecked() {
+            Exception e = new IllegalStateException();
+            assertThat(e, where(DiggExceptions::asUnchecked, sameInstance(e)));
+        }
+
+        @Test
+        void UnknownCheckedExceptionBecomesRuntimeException() {
+            class MyCheckedException extends Exception {
+                public MyCheckedException() {
+                    super("Who in their right mind would define their own checked exception");
+                }
+            }
+            RuntimeException uncheckedException = asUnchecked(new MyCheckedException());
+            assertAll(
+                    () -> assertThat(uncheckedException, where(Object::getClass, is(RuntimeException.class))),
+                    () -> assertThat(uncheckedException, where(Exception::getMessage, containsString("DiggExceptionsTest.AsUnchecked.MyCheckedException"))),
+                    () -> assertThat(uncheckedException, where(Exception::getMessage, containsString("Who in their right mind"))));
+        }
+    }
 
 }

--- a/src/test/java/no/digipost/DiggExceptionsTest.java
+++ b/src/test/java/no/digipost/DiggExceptionsTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -124,6 +125,12 @@ public class DiggExceptionsTest {
                     () -> assertThat(uncheckedException, where(Exception::getMessage, containsString("DiggExceptionsTest.AsUnchecked.MyCheckedException"))),
                     () -> assertThat(uncheckedException, where(Exception::getMessage, containsString("Who in their right mind"))));
         }
+
+        @Test
+        void ioExceptionAsUncheckedIOException() {
+            assertThat(new IOException("error"), where(DiggExceptions::asUnchecked, instanceOf(UncheckedIOException.class)));
+        }
+
     }
 
 }


### PR DESCRIPTION
Some very minor enhancements to the utility for "translating" any exception into an unchecked one (which may always be thrown).

- when using the `asUnchecked` variants accepting a custom message, there was a chance that the custom message would be discarded, as the util would resort to casting the exception if it was already a RuntimeException, and thus not using the given message for a new exception wrapping the given one. This has now been fixed to _always_ wrap the given exception into a new one, if a custom message is supplied. This better follows the principle of least surprise.
- for `asUnchecked(e)` where `e` already is a RuntimeException, a cast will suffice, as no further context can be derived into wrapping the exception
- if translating an (checked) `IOException`, an `UncheckedIOException` is created, which maintains the semantics of the original exception. Other special cases may be added later.