### PR TITLE
Fix javadoc errors due to wrong header hierarchy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '1.8', '11' ]
+        java: [ '1.8', '11', '17' ]
 
     name: build java ${{ matrix.java }}
     steps:

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -36,7 +36,7 @@ import static java.util.stream.StreamSupport.stream;
 /**
  * Party people, turn up tha...
  *
- * <h2>&ndash;&ndash; {@link DiggBase} &ndash;&ndash;</h2>
+ * <p><strong>&ndash;&ndash; {@link DiggBase} &ndash;&ndash;</strong></p>
  *
  * <p>This class contains basic utilities. Basically.</p>
  */

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -36,7 +36,7 @@ import static java.util.stream.StreamSupport.stream;
 /**
  * Party people, turn up tha...
  *
- * <h1>&ndash;&ndash; {@link DiggBase} &ndash;&ndash;</h1>
+ * <h2>&ndash;&ndash; {@link DiggBase} &ndash;&ndash;</h2>
  *
  * <p>This class contains basic utilities. Basically.</p>
  */

--- a/src/main/java/no/digipost/DiggOptionals.java
+++ b/src/main/java/no/digipost/DiggOptionals.java
@@ -39,12 +39,12 @@ public final class DiggOptionals {
      * optional values will be attempted resolved. E.g. calling {@link Stream#findFirst() .findFirst()} will only resolve
      * as many {@code Optional}s needed until the first present one is encountered.
      *
-     * <h2>Note on parallel streams</h2>
+     * <h4>Note on parallel streams</h4>
      * The returned stream will be sequential and appropriate for use to resolve several {@link Optional}s in a deterministic
      * order, or for instance to find the first present value of a prioritized set of possible ways to resolve it. One should
      * be <em>very</em> (as always with streams) careful with {@link Stream#parallel() parallelizing} the stream, as you generally
      * have no control with how the resolvers will be run. For instance, {@link Stream#findAny() .parallel().findAny()} will indeed return
-     * the the first resolved value, <em>but still block until the workers already started by the stream has terminated</em>.
+     * the first resolved value, <em>but still block until the workers already started by the stream has terminated</em>.
      *
      * @param <T> The type of the given {@code Optional}s and returned {@code Stream}.
      * @param optionalResolvers The operations resolving {@code Optional}s to convert to a {@code Stream}.

--- a/src/main/java/no/digipost/DiggOptionals.java
+++ b/src/main/java/no/digipost/DiggOptionals.java
@@ -39,7 +39,7 @@ public final class DiggOptionals {
      * optional values will be attempted resolved. E.g. calling {@link Stream#findFirst() .findFirst()} will only resolve
      * as many {@code Optional}s needed until the first present one is encountered.
      *
-     * <h4>Note on parallel streams</h4>
+     * <p><strong>Note on parallel streams:</strong></p>
      * The returned stream will be sequential and appropriate for use to resolve several {@link Optional}s in a deterministic
      * order, or for instance to find the first present value of a prioritized set of possible ways to resolve it. One should
      * be <em>very</em> (as always with streams) careful with {@link Stream#parallel() parallelizing} the stream, as you generally


### PR DESCRIPTION
`mvn install` failed due to these errors.