### PR TITLE
Fix typo in editorconfig, reformat indents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,9 +25,8 @@ charset = utf-8
 continuation_indent_size = 8
 
 [*.yml]
-indent_style = space
 indent_size = 2
 
 [*.md]
-indent_style = tabs
+indent_style = tab
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ _Digg_ is available in [![Maven Central Repository](https://maven-badges.herokua
 
 ```xml
 <dependency>
-    <groupId>no.digipost</groupId>
-    <artifactId>digg</artifactId>
-    <version>0.32</version>
+	<groupId>no.digipost</groupId>
+	<artifactId>digg</artifactId>
+	<version>0.32</version>
 </dependency>
 ```
 
@@ -56,25 +56,25 @@ _Digg_ contains some extensions of the Java Collections and Streams API to provi
 // with the regular "toList" collector. Unfortunately this looses
 // the non-emptyness quality when collecting back to a List.
 List<String> list = NonEmptyList.of(1, 2, 3).stream()
-        .map(String::valueOf)
-        .collect(toList());
+	.map(String::valueOf)
+	.collect(toList());
 ```
 
 It is possible to preserve the non-emptyness going from list to stream, and back to list, on a type level, using a particular collector for `NonEmptyList`, found in the `DiggCollectors` class:
 
 ```java
 NonEmptyList<String> list = NonEmptyList.of(1, 2, 3).stream()
-        .map(String::valueOf)
-        .collect(toNonEmptyList()); //static imported from DiggCollectors
+	.map(String::valueOf)
+	.collect(toNonEmptyList()); //static imported from DiggCollectors
 ```
 
 The `DiggCollectos.toNonEmptyList()` collector is fully usable with both `NonEmptyStream` and regular streams, which can be demonstrated when _filtering_ a non-empty stream. As filtering must necessarily break the guarantee the stream continues to be non-empty, a regular stream is returned from `NonEmptyStream.filter(..)`, and you will appropriately get an `Optional<NonEmptyList>` if you try to collect the result with `toNonEmptyStream()`:
 
 ```java
 Optional<NonEmptyList<String>> list = NonEmptyList.of(1, 2, 3).stream()
-        .filter(i -> i > 1)
-        .map(String::valueOf)
-        .collect(toNonEmptyList());
+	.filter(i -> i > 1)
+	.map(String::valueOf)
+	.collect(toNonEmptyList());
 ```
 
 Another use for this could be to get a property expected to be identical for multiple elements of a non-empty list, and throw an exception if this is not the case, because that would be an illegal state (and a bug in your program):
@@ -83,9 +83,9 @@ Another use for this could be to get a property expected to be identical for mul
 NonEmptyList<Person> persons;
 ...
 PersonType = persons.stream()
-        .map(Person::getType)
-        .distinct()
-        .collect(allowAtMostOne());
+	.map(Person::getType)
+	.distinct()
+	.collect(allowAtMostOne());
 ```
 Using `.collect(allowAtMostOne())` on a regular stream which may be empty would result in an `Optional<PersonType>`, but because the stream originated from a non-empty list and the map and distinct operations does not create a possibly empty stream, there is no need to produce an `Optional` from the collect operation.
 


### PR DESCRIPTION
"tabs" is an invalid value. Not sure why we are using tabs in markdown files, but spaces everywhere else, though.

The `indent_style = space` for yml files is unnecessary, as it inherits the default settings above.