### PR TITLE
Count-down TargetState

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.1.0</version>
                     <configuration>
                         <rules>
                             <requireMavenVersion>
@@ -169,7 +169,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.10.1</version>
                     <configuration>
                         <compilerArgs>
                             <arg>-Xlint</arg>
@@ -178,27 +178,27 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>3.0.0-M7</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
@@ -215,12 +215,12 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.8.1</version>
+                    <version>2.14.2</version>
                     <configuration>
                         <generateBackupPoms>false</generateBackupPoms>
                     </configuration>
@@ -228,7 +228,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.15.3</version>
+                    <version>0.15.7</version>
                     <configuration>
                         <oldVersion>
                             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.4.1</version>
                     <configuration>
                         <tags>
                             <tag>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,14 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.8.0-M1</version>
+                <version>5.9.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>4.11.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -72,13 +79,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1.1-jre</version>
+            <version>31.1-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -90,7 +96,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.6.1</version>
+            <version>3.12.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/no/digipost/concurrent/CountDown.java
+++ b/src/main/java/no/digipost/concurrent/CountDown.java
@@ -44,6 +44,9 @@ public final class CountDown implements TargetState {
      *              and switches to only return {@code true}.
      */
     public CountDown(long count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("negative count: " + count);
+        }
         this.count = new AtomicLong(count);
     }
 

--- a/src/main/java/no/digipost/concurrent/CountDown.java
+++ b/src/main/java/no/digipost/concurrent/CountDown.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.concurrent;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A count down implementation of {@link TargetState},
+ * which will count the invocations of {@link #yet()} and
+ * return {@code true} <em>after</em> a given amount of invocations.
+ * <p>
+ * The implementation is thread-safe in the sense that it is guaranteed
+ * that {@link #yet()} will return {@code false} an <em>exact</em> amount
+ * of times, regardless of different threads invoking {@code yet()},
+ * before switching to only return {@code true}.
+ * <p>
+ * This can often serve for testing purposes where you would
+ * like a controlled amount of queries to a {@code TargetState},
+ * before it changes.
+ */
+public final class CountDown implements TargetState {
+
+    private final AtomicLong count;
+
+    /**
+     * Create a new count down from the given start {@code count}.
+     *
+     * @param count the number of invocations where {@link #yet()} will
+     *              indicate the count down is not finished yet, i.e.
+     *              the number of times {@code yet()} will return {@code false},
+     *              and switches to only return {@code true}.
+     */
+    public CountDown(long count) {
+        this.count = new AtomicLong(count);
+    }
+
+    @Override
+    public boolean yet() {
+        return count.getAndUpdate(i -> i > 0 ? i - 1 : i) == 0;
+    }
+
+    @Override
+    public String toString() {
+        return "count down currently at " + count.get();
+    }
+
+}

--- a/src/test/java/no/digipost/concurrent/CountDownTest.java
+++ b/src/test/java/no/digipost/concurrent/CountDownTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.concurrent;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.whereNot;
+
+class CountDownTest {
+
+    @Test
+    void reachesTargetStateAfterNthQuery() {
+        CountDown countDown = new CountDown(2);
+        assertThat(countDown, whereNot(TargetState::yet));
+        assertThat(countDown, whereNot(TargetState::yet));
+        assertThat(countDown, where(TargetState::yet));
+    }
+
+    @Test
+    void countDownGuaranteesAnExactAmountCrossThreads() {
+        long count = 50_000;
+        CountDown countDown = new CountDown(count);
+        long invocationsBeforeZero = IntStream.generate(() -> countDown.yet() ? 0 : 1)
+            .parallel()
+            .limit(count * 5)
+            .filter(i -> i == 1)
+            .count();
+        assertThat(invocationsBeforeZero, is(count));
+    }
+
+}

--- a/src/test/java/no/digipost/concurrent/CountDownTest.java
+++ b/src/test/java/no/digipost/concurrent/CountDownTest.java
@@ -21,6 +21,7 @@ import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static uk.co.probablyfine.matchers.Java8Matchers.whereNot;
 
@@ -32,6 +33,17 @@ class CountDownTest {
         assertThat(countDown, whereNot(TargetState::yet));
         assertThat(countDown, whereNot(TargetState::yet));
         assertThat(countDown, where(TargetState::yet));
+    }
+
+    @Test
+    void aZeroCountDownIsImmediatelyDone() {
+        CountDown countDown = new CountDown(0);
+        assertThat(countDown, where(TargetState::yet));
+    }
+
+    @Test
+    void doesNotAllowNegativeCount() {
+        assertThrows(IllegalArgumentException.class, () -> new CountDown(-1));
     }
 
     @Test


### PR DESCRIPTION
A `TargetState` is used to determine is a certain state has been reached yet, commonly by querying `TargetState.yet()`:
```java
final TargetState cancelled;
...
    if (!cancelled.yet()) {
        // do work 
    }
```
A `CountDown` is an internally managed `TargetState` which by itself reaches its target state of "count down reached zero" after an exact amount of queries to `CountDown.yet()`. See `CountDownTest.reachesTargetStateAfterNthQuery` which exactly defines the behavior.

The use-case for this will commonly be for testing.