### PR TITLE
Add support for certain non-trivial Stream searching

### DIFF
--- a/src/main/java/no/digipost/DiggCollectors.java
+++ b/src/main/java/no/digipost/DiggCollectors.java
@@ -22,6 +22,7 @@ import no.digipost.collection.NonEmptyList;
 import no.digipost.concurrent.OneTimeAssignment;
 import no.digipost.stream.EmptyResultIfEmptySourceCollector;
 import no.digipost.stream.NonEmptyStream;
+import no.digipost.stream.SubjectFilter;
 import no.digipost.tuple.Tuple;
 import no.digipost.tuple.ViewableAsTuple;
 import no.digipost.util.ViewableAsOptional;
@@ -34,6 +35,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -47,6 +49,37 @@ import static java.util.stream.Collectors.toList;
  * Various {@link java.util.stream.Collector} implementations.
  */
 public final class DiggCollectors {
+
+
+    /**
+     * Create a collector used for finding and accumulating a specific result,
+     * where applying a filter is not adequate. The returned
+     * {@link SubjectFilter subject filter} is used for
+     * further specifying the final (compound) condition for the result to find.
+     * <p>
+     * When searching for a result <em>in context</em> of other elements, you must carefully
+     * ensure the source to have appropriate ordering and parallelity (or probably rather lack thereof)
+     * for the correct and expected operation of the collector.
+     * <p>
+     * Note: because {@link Collector collectors} are applied to <em>all</em> elements
+     * in a Stream, care should be taken to exclude non-applicable elements e.g. using
+     * a {@link Stream#filter(Predicate) filter}, and {@link Stream#limit(long) limit}
+     * especially for infinite Streams, before collecting.
+     *
+     *
+     * @param <T> The element type which is inspected by the subject filter. This type is
+     *            typically the same as the element type of the Stream the final collector
+     *            is applied to.
+     *
+     * @param subjectElement the predicate for selecting a subject element for further use
+     *                       in accumulating a result from applying the final collector.
+     *
+     * @return the subject filter for the collector, which must be further specified
+     *         to build the final collector
+     */
+    public static <T> SubjectFilter<T> find(Predicate<T> subjectElement) {
+        return new SubjectFilter<>(subjectElement);
+    }
 
 
     /**

--- a/src/main/java/no/digipost/stream/AtomicReferenceFolder.java
+++ b/src/main/java/no/digipost/stream/AtomicReferenceFolder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.stream;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+/**
+ * A consumer function for "folding" a value with an {@link AtomicReference}.
+ *
+ * @param <T> The type of the value this function folds.
+ */
+@FunctionalInterface
+interface AtomicReferenceFolder<T> extends BiConsumer<AtomicReference<T>, T> {
+
+    static <T> AtomicReferenceFolder<T> clearReference() {
+        return (ref, value) -> ref.set(null);
+    }
+
+    static <T> AtomicReferenceFolder<T> keepFirst(Predicate<? super T> predicate) {
+        return (currentRef, candidateElement) ->
+            currentRef.accumulateAndGet(candidateElement, (current, candidate) -> current == null && predicate.test(candidate) ? candidate : current);
+    }
+
+    static <T> AtomicReferenceFolder<T> keepLast(Predicate<? super T> predicate) {
+        return (currentRef, candidateElement) -> {
+            if (predicate.test(candidateElement)) {
+                currentRef.set(candidateElement);
+            }
+        };
+    }
+
+    default AtomicReferenceFolder<T> doInsteadIf(Predicate<? super T> valuePredicate, AtomicReferenceFolder<T> foldOperation) {
+        return doInsteadIf((ref, value) -> valuePredicate.test(value), foldOperation);
+    }
+
+    default AtomicReferenceFolder<T> doInsteadIf(BiPredicate<? super AtomicReference<T>, ? super T> refAndValuePredicate, AtomicReferenceFolder<T> foldOperation) {
+        return (ref, value) -> {
+            if (refAndValuePredicate.test(ref, value)) {
+                foldOperation.accept(ref, value);
+            } else {
+                this.accept(ref, value);
+            }
+        };
+    }
+}

--- a/src/main/java/no/digipost/stream/AtomicReferenceFoldingCollector.java
+++ b/src/main/java/no/digipost/stream/AtomicReferenceFoldingCollector.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.stream;
+
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import static java.util.Collections.unmodifiableSet;
+import static java.util.stream.Collector.Characteristics.CONCURRENT;
+
+final class AtomicReferenceFoldingCollector<T> implements Collector<T, AtomicReference<T>, Optional<T>> {
+
+    private final AtomicReferenceFolder<T> accumulator;
+    private final Set<Characteristics> characteristics;
+
+    AtomicReferenceFoldingCollector(AtomicReferenceFolder<T> accumulator) {
+        this(accumulator, EnumSet.of(CONCURRENT));
+    }
+
+    AtomicReferenceFoldingCollector(AtomicReferenceFolder<T> accumulator, Set<Characteristics> characteristics) {
+        this.accumulator = accumulator;
+        this.characteristics = unmodifiableSet(characteristics);
+    }
+
+
+    @Override
+    public AtomicReferenceFolder<T> accumulator() {
+        return accumulator;
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+        return characteristics;
+    }
+
+    /**
+     * The combiner, while thread-safe, has essentially undefined behavior if combining two
+     * found elements, because there is no way to tell if one or the other should be prioritized.
+     * In all cases of combining one found element with a not found, the found element will be
+     * returned from the function.
+     */
+    @Override
+    public BinaryOperator<AtomicReference<T>> combiner() {
+        return (ref1, ref2) -> {
+            ref1.compareAndSet(null, ref2.get());
+            return ref1;
+        };
+    }
+
+    @Override
+    public Function<AtomicReference<T>, Optional<T>> finisher() {
+        return ref -> Optional.ofNullable(ref.get());
+    }
+
+    @Override
+    public Supplier<AtomicReference<T>> supplier() {
+        return AtomicReference::new;
+    }
+}

--- a/src/main/java/no/digipost/stream/SubjectFilter.java
+++ b/src/main/java/no/digipost/stream/SubjectFilter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) Posten Norge AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.digipost.stream;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collector;
+
+import static java.util.function.Predicate.isEqual;
+import static no.digipost.stream.AtomicReferenceFolder.clearReference;
+import static no.digipost.stream.AtomicReferenceFolder.keepFirst;
+import static no.digipost.stream.AtomicReferenceFolder.keepLast;
+
+/**
+ * The initial subject filter for building a searching {@code Collector}.
+ * The {@link Collector} is acquired by invoking a method to finalize the
+ * (compound) condition for accumulating the result across the elements
+ * the collector will be applied to.
+ *
+ * @param <T> the type of elements this subject filter inspects
+ *
+ * @see #keepFirstNotFollowedBy(Predicate)
+ * @see #keepLastNotFollowedBy(Predicate)
+ */
+public final class SubjectFilter<T> {
+    private final Predicate<T> subjectElement;
+
+    public SubjectFilter(Predicate<T> subjectElement) {
+        this.subjectElement = subjectElement;
+    }
+
+    public Collector<T, ?, Optional<T>> keepFirstNotFollowedBy(T cancellingElement) {
+        return keepFirstNotFollowedBy(isEqual(cancellingElement));
+    }
+
+    public Collector<T, ?, Optional<T>> keepFirstNotFollowedBy(Predicate<? super T> cancellingElement) {
+        return new AtomicReferenceFoldingCollector<>(keepFirst(subjectElement).doInsteadIf(cancellingElement, clearReference()));
+    }
+
+    public Collector<T, ?, Optional<T>> keepLastNotFollowedBy(T cancellingElement) {
+        return keepLastNotFollowedBy(isEqual(cancellingElement));
+    }
+
+    public Collector<T, ?, Optional<T>> keepLastNotFollowedBy(Predicate<? super T> cancellingElement) {
+        return new AtomicReferenceFoldingCollector<>(keepLast(subjectElement).doInsteadIf(cancellingElement, clearReference()));
+    }
+}


### PR DESCRIPTION
By non-trivial I mean searching which uses some kind of "contextual" condition in addition to a matching predicate.

The feature currently offered is to find a certain element, which is traditionally done using `.filter(..)`, but with the additional constraint that the element must _not_ be followed by a certain other element.

The usage can look something like this:
```java
Optional<Event> failedEvent = stream.collect(find(FAILED).keepFirstNotFollowedBy(RESTORED));
```
(see "Example - analyzing events" below for a more complete example)


## API design

The search is realized with a [Collector](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/stream/Collector.html) which is built by first expressing the subject element you are interested in, using `DiggCollectors.find(Predicate)`. The returned object offers the API to compose the full compound search condition.

Currently, and introduced in this PR, the returned object offers methods to specify that the element you search for can _not_ be followed by a certain other element. In addition you also specify if you want the first or last encountered element, should there be multiple applicable elements which is not followed by any "cancelling" element.

This should allow for further extending the API with other search cases. For example it should be possible to extract a sub-collection of successive events given the initial subject predicate, and then specifying the condition for when to end the extraction.

It follows that the use cases for this typically requires Streams which are _ordered_ and _sequential_, which must be ensured by the developer, or you may get unpredictable results. One example of such source of elements may be a chronological stream of events, and you are interested in finding an event but only if it has not been "voided" by a certain following event.

### Tradeoffs

The existing standard collectors offered by the JDK and in widespread use (e.g. `.toList()`, `.groupingBy(..)`, etc) generally communicate that the entire stream will be traversed to produce a result. A collector has no facilities to send a "halting signal", i.e. to decide that the result is complete at any point, and cancel any further elements to be offered to the collector for processing/collecting. It can of course choose to discard any offered element at any point.

Currently, I consider the API to communicate that the entirety of the Stream must be traversed, because of the condition of the "any following element" which may affect the result. But an API such as this _may_ evolve to communicate that once a result is obtained, the rest of the Stream is discarded and not processed, and this is not the case. As with all uses of collectors, the Stream pipeline should be forged to filter only relevant elements, and must be finite. 

This feature would probably be a better fit as a `Gatherer`, currently [in preview in not-yet-released OpenJDK 22](https://openjdk.org/jeps/461), as it would allow termination of the Stream traversal. And having it as an intermediate operation could also enable more flexibility for further processing _after_ the _find_-operation.
> The integrator function [of a Gatherer] (...) can also terminate processing before reaching the end of the input stream; for example, a gatherer searching for the largest of a stream of integers can terminate if it detects Integer.MAX_VALUE.


## Example - analyzing events

Given this model of events:
```java
record Event(Type type, LocalDateTime at) {
    enum Type implements Predicate<Event> { INIT, MOVING_ALONG, FAILED, RESTORED;
        @Override public boolean test(Event e) {
            return this == e.type();
        }
    }
}
```

And the following events happened resolved in chronnological order:
```java
var now = LocalDateTime.of(2024, 1, 4, 8, 8);
var firstFailure = now.plusSeconds(1);
var firstFailureAfterRestore = now.plusSeconds(10);
var yetAnotherFailure = firstFailureAfterRestore.plusSeconds(10);

var events = List.of(
    new Event(Event.Type.INIT, now),
    new Event(Event.Type.FAILED, firstFailure),
    new Event(Event.Type.RESTORED, firstFailure.plusSeconds(1)),
    new Event(Event.Type.MOVING_ALONG, firstFailure.plusSeconds(2)),
    new Event(Event.Type.FAILED, firstFailureAfterRestore),
    new Event(Event.Type.MOVING_ALONG, firstFailureAfterRestore.plusSeconds(1)),
    new Event(Event.Type.FAILED, yetAnotherFailure),
    new Event(Event.Type.MOVING_ALONG, yetAnotherFailure.plusSeconds(20)));
```


The following tests shows resolving the first applicable failure event, and the last applicable failure event, both happening after the restoring which happened as the third event.

Lastly, we append yet another restored-event, which voids all the contained failures.

```java
Optional<Event> failure; // failure may or may not be the result

failure = events.stream()
    .collect(find(Event.Type.FAILED).keepFirstNotFollowedBy(Event.Type.RESTORED));
assertThat(failure.get(), is(new Event(Event.Type.FAILED, firstFailureAfterRestore)));

failure = events.stream()
        .collect(find(Event.Type.FAILED).keepLastNotFollowedBy(Event.Type.RESTORED));
assertThat(failure.get(), is(new Event(Event.Type.FAILED, yetAnotherFailure)));

failure = Stream
        .concat(events.stream(), Stream.of(new Event(Event.Type.RESTORED, yetAnotherFailure.plusDays(1))))
        .collect(find(Event.Type.FAILED).keepLastNotFollowedBy(Event.Type.RESTORED));
assertTrue(failure.isEmpty());
```
