### PR TITLE
NonEmptyList copy-constructors accept Collection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.3</version>
+                    <version>3.2.5</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -244,7 +244,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.18.3</version>
+                    <version>0.18.5</version>
                     <configuration>
                         <parameter>
                             <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.1</version>
+                <version>5.10.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -63,7 +63,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-bom</artifactId>
-                <version>2.0.10</version>
+                <version>2.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.15.5</version>
+            <version>3.15.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>jul-to-slf4j-junit-extension</artifactId>
-            <version>1.0</version>
+            <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/no/digipost/collection/NonEmptyList.java
+++ b/src/main/java/no/digipost/collection/NonEmptyList.java
@@ -182,6 +182,21 @@ public interface NonEmptyList<E> extends List<E> {
 
     /**
      * Try to construct a non-empty list from copying the elements
+     * of a given list, which may be empty.
+     *
+     * @param <E> the type of elements in the list.
+     * @param list the list, which may be empty
+     *
+     * @return the resulting non-empty list,
+     *         or {@link Optional#empty()} if the given list is empty
+     */
+    static <E> Optional<NonEmptyList<E>> copyOf(List<E> list) {
+        return copyOf((Collection<E>) list);
+    }
+
+
+    /**
+     * Try to construct a non-empty list from copying the elements
      * of a given collection, which may be empty.
      *
      * @param <E> the type of elements in the collection.
@@ -207,6 +222,29 @@ public interface NonEmptyList<E> extends List<E> {
      */
     static <E> Optional<NonEmptyList<E>> copyOf(E[] array) {
         return copyOf(asList(array));
+    }
+
+
+    /**
+     * <strong>Unsafe</strong> construction of non-empty list from copying the
+     * elements of a list assumed to be non-empty.
+     * <p>
+     * This method should only be used when the given list is <em>guarantied</em>
+     * to be empty, and thus offers a fail-fast way to introduce the non-empty
+     * quality on a type level. Use {@link #copyOf(List)} if you need
+     * more flexibility in handling of a possible empty list.
+     *
+     * @param <E> the type of elements in the list.
+     * @param nonEmptyList the list, which is assumed not to be empty
+     *
+     * @return the resulting non-empty list
+     *
+     * @throws IllegalArgumentException if the given list is empty
+     *
+     * @see #copyOf(List)
+     */
+    static <E> NonEmptyList<E> copyOfUnsafe(List<E> nonEmptyList) {
+        return copyOfUnsafe((Collection<E>) nonEmptyList);
     }
 
 

--- a/src/main/java/no/digipost/collection/NonEmptyList.java
+++ b/src/main/java/no/digipost/collection/NonEmptyList.java
@@ -18,6 +18,7 @@ package no.digipost.collection;
 import no.digipost.stream.NonEmptyStream;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,7 +37,7 @@ import static java.util.Arrays.asList;
  * relied on.
  * <p>
  * If you need to construct non-empty lists based on another container you
- * need to further mutate, consider using one of the {@link #copyOf(List) copyOf}
+ * need to further mutate, consider using one of the {@link #copyOf(Collection) copyOf}
  * constructors, which will copy the given references so that any subsequent changes to the
  * to the given source container will not be reflected in the created non-empty list. (As usual,
  * this is a shallow copy, meaning that the instances themselves can of course be mutated by anything.)
@@ -181,16 +182,16 @@ public interface NonEmptyList<E> extends List<E> {
 
     /**
      * Try to construct a non-empty list from copying the elements
-     * of a given list, which may be empty.
+     * of a given collection, which may be empty.
      *
-     * @param <E> the type of elements in the list.
-     * @param list the list, which may be empty
+     * @param <E> the type of elements in the collection.
+     * @param collection the collection, which may be empty
      *
      * @return the resulting non-empty list,
-     *         or {@link Optional#empty()} if the given list is empty
+     *         or {@link Optional#empty()} if the given collection is empty
      */
-    static <E> Optional<NonEmptyList<E>> copyOf(List<E> list) {
-        return firstOf(list).map(first -> NonEmptyList.of(first, new ArrayList<>(list.subList(1, list.size()))));
+    static <E> Optional<NonEmptyList<E>> copyOf(Collection<E> collection) {
+        return of(new ArrayList<>(collection));
     }
 
 
@@ -211,24 +212,24 @@ public interface NonEmptyList<E> extends List<E> {
 
     /**
      * <strong>Unsafe</strong> construction of non-empty list from copying the
-     * elements of a list assumed to be non-empty.
+     * elements of a collection assumed to be non-empty.
      * <p>
-     * This method should only be used when the given list is <em>guarantied</em>
+     * This method should only be used when the given collection is <em>guarantied</em>
      * to be empty, and thus offers a fail-fast way to introduce the non-empty
-     * quality on a type level. Use {@link #copyOf(List)} if you need
+     * quality on a type level. Use {@link #copyOf(Collection)} if you need
      * more flexibility in handling of a possible empty list.
      *
      * @param <E> the type of elements in the list.
-     * @param nonEmptyList the list, which is assumed not to be empty
+     * @param nonEmptyCollection the collection, which is assumed not to be empty
      *
      * @return the resulting non-empty list
      *
      * @throws IllegalArgumentException if the given list is empty
      *
-     * @see #copyOf(List)
+     * @see #copyOf(Collection)
      */
-    static <E> NonEmptyList<E> copyOfUnsafe(List<E> nonEmptyList) {
-        return copyOf(nonEmptyList).orElseThrow(() -> new IllegalArgumentException("empty list"));
+    static <E> NonEmptyList<E> copyOfUnsafe(Collection<E> nonEmptyCollection) {
+        return copyOf(nonEmptyCollection).orElseThrow(() -> new IllegalArgumentException("empty list"));
     }
 
 


### PR DESCRIPTION
Instead of requiring a List, which is unnecessary strict. This aligns with the JDK copy constructors for lists:

- [public ArrayList(Collection<? extends E> c)](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html#ArrayList-java.util.Collection-)
- [List.copyOf](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/List.html#copyOf(java.util.Collection))


Keeping around the constructors accepting Lists, because of backwards compatibility.