### PR TITLE
forceOnAll will catch exception from resolving Stream element

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.2</version>
+                <version>5.11.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -63,7 +63,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-bom</artifactId>
-                <version>2.0.12</version>
+                <version>2.0.16</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -79,13 +79,13 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.2</version>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.15.6</version>
+            <version>3.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.15.1</version>
+            <version>2.17.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.15.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -163,11 +163,11 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>4.3</version>
+                    <version>4.6</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <rules>
                             <requireMavenVersion>
@@ -190,7 +190,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>3.13.0</version>
                     <configuration>
                         <compilerArgs>
                             <arg>-Xlint</arg>
@@ -199,23 +199,23 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
@@ -223,7 +223,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.6.3</version>
+                    <version>3.10.0</version>
                     <configuration>
                         <tags>
                             <tag>
@@ -236,12 +236,12 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.16.2</version>
+                    <version>2.17.1</version>
                     <configuration>
                         <generateBackupPoms>false</generateBackupPoms>
                     </configuration>
@@ -249,7 +249,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.18.5</version>
+                    <version>0.23.0</version>
                     <configuration>
                         <parameter>
                             <includes>

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -222,8 +222,8 @@ public final class DiggBase {
 
     /**
      * Create a stream which will yield the exceptions (if any) from invoking an {@link ThrowingConsumer action} on
-     * several {@code instances}. Consuming the stream will ensure that <strong>all</strong> instances will have
-     * the action invoked on them, and any exceptions happening will be available through the returned stream.
+     * several {@code instances}. Consuming the returned stream will ensure that <strong>all</strong> instances will have
+     * the action attempted on them, and any exceptions happening will be available through the returned stream.
      *
      * @param action the action to execute for each provided instance
      * @param instances the instances to act on with the provided {@code action}.
@@ -239,8 +239,12 @@ public final class DiggBase {
 
     /**
      * Create a stream which will yield the exceptions (if any) from invoking an {@link ThrowingConsumer action} on
-     * several {@code instances}. Consuming the stream will ensure that <strong>all</strong> instances will have
-     * the action invoked on them, and any exceptions happening will be available through the returned stream.
+     * several {@code instances}. This also includes exceptions thrown from <em>traversing</em> the given {@link Stream}
+     * of instances, i.e. should resolving an element from the {@code Stream} cause an exception, it will be caught and
+     * included in the returned {@code Stream}.
+     * <p>
+     * Consuming the returned stream will ensure that <strong>all</strong> traversed instances will have
+     * the action attempted on them, and any exceptions happening will be available through the returned stream.
      *
      * @param action the action to execute for each provided instance
      * @param instances the instances to act on with the provided {@code action}.

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -21,6 +21,7 @@ import no.digipost.util.ThrowingAutoClosed;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.function.Consumer;
@@ -247,7 +248,9 @@ public final class DiggBase {
      * @return the Stream with exceptions, if any
      */
     public static <T> Stream<Exception> forceOnAll(ThrowingConsumer<? super T, ? extends Exception> action, Stream<T> instances) {
-        return StreamSupport.stream(new FlatMapToExceptionSpliterator<>(action, instances.spliterator()), instances.isParallel());
+        return StreamSupport.stream(
+                new FlatMapToExceptionSpliterator<>(action, instances.filter(Objects::nonNull).spliterator()),
+                instances.isParallel());
     }
 
     private static final class FlatMapToExceptionSpliterator<W> implements Spliterator<Exception> {

--- a/src/main/java/no/digipost/DiggStreams.java
+++ b/src/main/java/no/digipost/DiggStreams.java
@@ -19,6 +19,7 @@ import no.digipost.function.ObjIntFunction;
 import no.digipost.function.ObjLongFunction;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,6 +31,18 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static java.lang.Integer.toBinaryString;
+import static java.util.Spliterator.CONCURRENT;
+import static java.util.Spliterator.DISTINCT;
+import static java.util.Spliterator.IMMUTABLE;
+import static java.util.Spliterator.NONNULL;
+import static java.util.Spliterator.ORDERED;
+import static java.util.Spliterator.SIZED;
+import static java.util.Spliterator.SORTED;
+import static java.util.Spliterator.SUBSIZED;
+import static java.util.stream.Collectors.joining;
+import static no.digipost.DiggBase.friendlyName;
 
 /**
  * Utilities for working with {@link Stream}s.
@@ -194,6 +207,35 @@ public final class DiggStreams {
             }
         };
         return StreamSupport.stream(spliterator, false);
+    }
+
+
+    /**
+     * Get a description of {@link Spliterator#characteristics() characteristics} of a
+     * {@code Spliterator}. The returned text is is solely intended for debugging and
+     * logging purposes, and contents and format may change at any time.
+     *
+     * @param spliterator the Spliterator
+     * @return the description
+     */
+    public static String describeCharacteristics(Spliterator<?> spliterator) {
+        int value = spliterator.characteristics();
+        if (value == 0) {
+            return friendlyName(spliterator.getClass()) + " with no enabled characteristics";
+        } else {
+            String enabledCharacteristics = Stream.of(
+                        spliterator.hasCharacteristics(SIZED) ? "sized" : null,
+                        spliterator.hasCharacteristics(SUBSIZED) ? "subsized" : null,
+                        spliterator.hasCharacteristics(DISTINCT) ? "distinct" : null,
+                        spliterator.hasCharacteristics(NONNULL) ? "non-null" : null,
+                        spliterator.hasCharacteristics(IMMUTABLE) ? "immutable" : null,
+                        spliterator.hasCharacteristics(ORDERED) ? "ordered" : null,
+                        spliterator.hasCharacteristics(CONCURRENT) ? "concurrent" : null,
+                        spliterator.hasCharacteristics(SORTED) ? "sorted" : null)
+                    .filter(Objects::nonNull)
+                    .collect(joining(", ", "", ""));
+            return enabledCharacteristics + " " + friendlyName(spliterator.getClass()) + " (" + toBinaryString(value) + ")";
+        }
     }
 
 

--- a/src/test/java/no/digipost/DiggBaseTest.java
+++ b/src/test/java/no/digipost/DiggBaseTest.java
@@ -17,33 +17,46 @@ package no.digipost;
 
 import no.digipost.util.AutoClosed;
 import no.digipost.util.ThrowingAutoClosed;
-import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.InOrder;
 import org.quicktheories.WithQuickTheories;
 import org.quicktheories.core.Gen;
 import org.quicktheories.dsl.TheoryBuilder;
+import uk.co.probablyfine.matchers.StreamMatchers;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.iterate;
+import static java.util.stream.IntStream.rangeClosed;
 import static java.util.stream.Stream.generate;
 import static no.digipost.DiggBase.autoClose;
 import static no.digipost.DiggBase.close;
+import static no.digipost.DiggBase.forceOnAll;
 import static no.digipost.DiggBase.friendlyName;
 import static no.digipost.DiggBase.nonNull;
 import static no.digipost.DiggBase.throwingAutoClose;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -52,8 +65,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.co.probablyfine.matchers.Java8Matchers.where;
-import static uk.co.probablyfine.matchers.StreamMatchers.contains;
-import static uk.co.probablyfine.matchers.StreamMatchers.empty;
 
 public class DiggBaseTest implements WithQuickTheories {
 
@@ -89,13 +100,20 @@ public class DiggBaseTest implements WithQuickTheories {
 
     @Test
     public void extractOptionalValuesFromAnObject() {
-        assertThat(DiggBase.<String, Character>extractIfPresent("abc", s -> Optional.of(s.charAt(0)), s -> Optional.empty(), s -> Optional.of(s.charAt(2))), contains('a', 'c'));
-        assertThat(DiggBase.<String, Character>extractIfPresent("abc", s -> Optional.empty(), s -> Optional.empty()), empty());
+        assertThat(DiggBase.<String, Character>extractIfPresent("abc",
+                    s -> Optional.of(s.charAt(0)),
+                    s -> Optional.empty(),
+                    s -> Optional.of(s.charAt(2))),
+                StreamMatchers.contains('a', 'c'));
+        assertThat(DiggBase.<String, Character>extractIfPresent("abc",
+                    s -> Optional.empty(),
+                    s -> Optional.empty()),
+                StreamMatchers.empty());
     }
 
     @Test
     public void extractValuesIncludesEverythingEvenNulls() {
-        assertThat(DiggBase.<String, Character>extract("abc", s -> s.charAt(0), s -> null), contains('a', null));
+        assertThat(DiggBase.<String, Character>extract("abc", s -> s.charAt(0), s -> null), StreamMatchers.contains('a', null));
     }
 
     @Test
@@ -183,9 +201,82 @@ public class DiggBaseTest implements WithQuickTheories {
         Stream<Exception> closeExceptionsStream = close(generate(() -> closeable).limit(5).toArray(AutoCloseable[]::new));
         verifyNoInteractions(closeable);
         List<Exception> closeExceptions = closeExceptionsStream.collect(toList());
-        assertThat(closeExceptions, Matchers.contains(asList(instanceOf(IOException.class), instanceOf(IllegalStateException.class))));
+        assertThat(closeExceptions, contains(asList(instanceOf(IOException.class), instanceOf(IllegalStateException.class))));
         verify(closeable, times(5)).close();
         verifyNoMoreInteractions(closeable);
+    }
+
+    @Nested
+    @Timeout(4)
+    class ForceOnAll {
+
+        @Test
+        void runsOperationOnMultipleElements() {
+            List<Integer> consumed = new ArrayList<>();
+            List<Exception> exceptions = forceOnAll(consumed::add, 1, 2, 3).collect(toList());
+            assertThat(consumed, contains(1, 2, 3));
+            assertThat(exceptions, empty());
+        }
+
+        @Test
+        void exceptionsFromOperationAreCollected() {
+            List<Integer> onlyEvenNumbers = new ArrayList<>();
+            List<Exception> exceptions = forceOnAll(i -> {
+                    if (i % 2 != 0) throw new IllegalArgumentException(i + " is odd!");
+                    onlyEvenNumbers.add(i);
+                }, 1, 2, 3, 4).collect(toList());
+            assertThat(onlyEvenNumbers, contains(2, 4));
+            assertThat(exceptions, contains(
+                    where(Throwable::getMessage, is("1 is odd!")),
+                    where(Throwable::getMessage, is("3 is odd!"))));
+        }
+
+        @Test
+        void exceptionsFromTraversingStreamIsCollected() {
+            List<Double> consumed = new ArrayList<>();
+            List<Exception> exceptions = forceOnAll(consumed::add,
+                    iterate(2, num -> num - 1).limit(5).mapToDouble(denominator -> 2 / denominator).boxed())
+                    .collect(toList());
+
+            assertAll(
+                    () -> assertThat(exceptions, contains(isA(ArithmeticException.class))),
+                    () -> assertThat(consumed, contains(1.0, 2.0, -2.0, -1.0)));
+        }
+
+        @Test
+        void allElementsResolvedFromStreamException() {
+            List<Exception> exceptions = forceOnAll(e -> fail("action should never be invoked"),
+                    rangeClosed(1, 10).mapToObj(String::valueOf).map(s -> { throw new IllegalStateException(s); }))
+                    .collect(toList());
+
+            assertThat(exceptions, hasSize(10));
+        }
+
+        @Test
+        void lastElementsResolvedFromStreamException() {
+            List<Integer> consumed = new ArrayList<>();
+            List<Exception> exceptions = forceOnAll(consumed::add,
+                    iterate(2, i -> i + -1).limit(3).mapToObj(denominator -> 2 / denominator))
+                    .collect(toList());
+            assertAll(
+                    () -> assertThat(exceptions, contains(isA(ArithmeticException.class))),
+                    () -> assertThat(consumed, contains(1, 2)));
+        }
+
+        @Test
+        void worksWithParalellStreams() {
+            AtomicLong successes = new AtomicLong();
+            long failures = forceOnAll(__ -> successes.incrementAndGet(),
+                    iterate(0, i -> i + 1).limit(100_000).parallel()
+                        .map(i -> i % 4) // 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, ...
+                        .map(denominator -> 4 / denominator) // Fails with div by zero 1/4 of the times
+                        .boxed())
+                .count();
+
+            assertThat("3 times as much successes as failures: " + successes + " / " + failures,
+                    failures * 3, is(successes.get()));
+        }
+
     }
 
 }

--- a/src/test/java/no/digipost/DiggBaseTest.java
+++ b/src/test/java/no/digipost/DiggBaseTest.java
@@ -164,6 +164,8 @@ public class DiggBaseTest implements WithQuickTheories {
 
     interface MyAutoCloseableResource extends AutoCloseable {
         void done() throws IOException;
+        @Override
+        void close() throws RuntimeException;
     }
 
     @Test

--- a/src/test/java/no/digipost/DiggEnumsTest.java
+++ b/src/test/java/no/digipost/DiggEnumsTest.java
@@ -54,7 +54,7 @@ public class DiggEnumsTest {
 
         qt()
             .forAll(multipleEnums)
-            .asWithPrecursor(enums -> Stream.of(enums).map(Enum::name).collect(joining(" , ", "  ", "   ")))
+            .asWithPrecursor(enums -> Stream.of(enums).map(MyEnum::name).collect(joining(" , ", "  ", "   ")))
             .checkAssert((enums, commaSeparatedNames) -> assertThat(fromCommaSeparatedNames(commaSeparatedNames, MyEnum.class), contains(enums)));
 
     }
@@ -74,11 +74,11 @@ public class DiggEnumsTest {
     public void toStringConversionsAreSpecialCasesOfTheGenericBaseCase() {
         qt()
             .forAll(multipleEnums)
-            .check(enums -> toCommaSeparatedNames(enums).equals(toStringOf(Enum::name, joining(","), enums)));
+            .check(enums -> toCommaSeparatedNames(enums).equals(toStringOf(MyEnum::name, joining(","), enums)));
 
         qt()
             .forAll(multipleEnums)
-            .check(enums -> toNames(": ", enums).equals(toStringOf(Enum::name, joining(": "), enums)));
+            .check(enums -> toNames(": ", enums).equals(toStringOf(MyEnum::name, joining(": "), enums)));
 
         qt()
             .forAll(multipleEnums)

--- a/src/test/java/no/digipost/DiggIOTest.java
+++ b/src/test/java/no/digipost/DiggIOTest.java
@@ -17,27 +17,28 @@ package no.digipost;
 
 import no.digipost.function.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.function.Consumer;
 
 import static no.digipost.DiggIO.autoClosing;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class DiggIOTest {
+@ExtendWith(MockitoExtension.class)
+class DiggIOTest {
 
     @Test
-    public void closesResourceAfterSuccess() throws Exception {
-        AutoCloseable resource = mock(AutoCloseable.class);
+    void closesResourceAfterSuccess(@Mock AutoCloseable resource) throws Exception {
         autoClosing(r -> {}).accept(resource);
         verify(resource, times(1)).close();
     }
 
     @Test
-    public void closesResourceAfterFailure() throws Exception {
-        AutoCloseable resource = mock(AutoCloseable.class);
+    void closesResourceAfterFailure(@Mock AutoCloseable resource) throws Exception {
         Consumer<AutoCloseable> autoClosingConsumer = autoClosing((ThrowingConsumer<AutoCloseable, Exception>) r -> { throw new Exception(); });
         assertThrows(RuntimeException.class, () -> autoClosingConsumer.accept(resource));
         verify(resource, times(1)).close();

--- a/src/test/java/no/digipost/collection/BatchedIterableTest.java
+++ b/src/test/java/no/digipost/collection/BatchedIterableTest.java
@@ -36,11 +36,13 @@ class BatchedIterableTest {
 
     @Test
     void emptyBatch() {
-        Batches<Object> empty1 = new Batches<>();
+        @SuppressWarnings("unchecked")
+        Batches<?> empty1 = new Batches<>();
         assertThat(batched(empty1, b -> false), is(emptyIterable()));
         assertThat(empty1.fetches(), is(1));
 
-        Batches<Object> empty2 = new Batches<>();
+        @SuppressWarnings("unchecked")
+        Batches<?> empty2 = new Batches<>();
         assertThat(batched(empty2, b -> true), is(emptyIterable()));
         assertThat(empty2.fetches(), is(2));
     }

--- a/src/test/java/no/digipost/function/ThrowingFunctionTest.java
+++ b/src/test/java/no/digipost/function/ThrowingFunctionTest.java
@@ -16,6 +16,9 @@
 package no.digipost.function;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -26,10 +29,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 public class ThrowingFunctionTest {
 
     private final RuntimeException ex = new RuntimeException("fail");
@@ -55,16 +58,15 @@ public class ThrowingFunctionTest {
     }
 
     @Test
-    public void translateToEmptyOptionalAndDelegateExceptionToHandler() {
+    public void translateToEmptyOptionalAndDelegateExceptionToHandler(
+            @Mock Consumer<Exception> getException,
+            @Mock BiConsumer<Integer, Exception> getValueAndException) {
+
         ThrowingFunction<Integer, ?, Exception> fn = i -> {throw ex;};
 
-        @SuppressWarnings("unchecked")
-        Consumer<Exception> getException = mock(Consumer.class);
         assertThat(fn.ifException(getException).apply(42), is(empty()));
         verify(getException, times(1)).accept(ex);
 
-        @SuppressWarnings("unchecked")
-        BiConsumer<Integer, Exception> getValueAndException = mock(BiConsumer.class);
         assertThat(fn.ifException(getValueAndException).apply(42), is(empty()));
         verify(getValueAndException, times(1)).accept(42, ex);
     }

--- a/src/test/java/no/digipost/function/ThrowingRunnableTest.java
+++ b/src/test/java/no/digipost/function/ThrowingRunnableTest.java
@@ -16,16 +16,19 @@
 package no.digipost.function;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.function.Consumer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 public class ThrowingRunnableTest {
 
     private final RuntimeException ex = new RuntimeException();
@@ -45,10 +48,8 @@ public class ThrowingRunnableTest {
     }
 
     @Test
-    public void translateToEmptyOptionalAndDelegateExceptionToHandler() {
+    public void translateToEmptyOptionalAndDelegateExceptionToHandler(@Mock Consumer<Exception> handler) {
         ThrowingRunnable<Exception> fn = () -> {throw ex;};
-        @SuppressWarnings("unchecked")
-        Consumer<Exception> handler = mock(Consumer.class);
 
         fn.ifException(handler).run();
         verify(handler, times(1)).accept(ex);

--- a/src/test/java/no/digipost/function/ThrowingSupplierTest.java
+++ b/src/test/java/no/digipost/function/ThrowingSupplierTest.java
@@ -16,6 +16,9 @@
 package no.digipost.function;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -26,11 +29,11 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.co.probablyfine.matchers.Java8Matchers.where;
 
+@ExtendWith(MockitoExtension.class)
 class ThrowingSupplierTest {
 
     private final RuntimeException ex = new RuntimeException();
@@ -57,10 +60,8 @@ class ThrowingSupplierTest {
     }
 
     @Test
-    void translateToEmptyOptionalAndDelegateExceptionToHandler() {
+    void translateToEmptyOptionalAndDelegateExceptionToHandler(@Mock Consumer<Exception> handler) {
         ThrowingSupplier<?, Exception> fn = () -> {throw ex;};
-        @SuppressWarnings("unchecked")
-        Consumer<Exception> handler = mock(Consumer.class);
 
         assertThat(fn.ifException(handler).get(), is(empty()));
         verify(handler, times(1)).accept(ex);

--- a/src/test/java/no/digipost/io/InputStreamIteratorTest.java
+++ b/src/test/java/no/digipost/io/InputStreamIteratorTest.java
@@ -71,7 +71,7 @@ class InputStreamIteratorTest {
             InputStreamIterator iterator = new InputStreamIterator(inputStream, 2);
 
             assertThat(consumeToString(iterator, UTF_8), is("Some data"));
-            assertThat(iterator, whereNot(Iterator::hasNext));
+            assertThat(iterator, whereNot(Iterator<byte[]>::hasNext));
 
             assertThrows(NoSuchElementException.class, iterator::next);
         }


### PR DESCRIPTION
The expectation from [forceOnAll](https://javadoc.io/static/no.digipost/digg/0.35/no/digipost/DiggBase.html#forceOnAll(no.digipost.function.ThrowingConsumer,T...)) is to _force_ an attempt of execution of an operation on all elements. This works as intended when the elements are _already resolved_, as they are when passed as an array. But a `Stream` may resolve it's elements from any source, also sources which can typically fail, e.g. if the element are sourced from an API request. By default, an exception occurring when the Stream tries to _yield_ an element for the pipeline of filters, maps, etc, will abort the Stream terminal operation, and be immediately thrown.

In order to "tap into" the resolving logic, the approach of flatmapping to a (potential) exception using the regular Stream API has now been replaced with a bit more "low-level" use of a Spliterator which will invoke the intended side-effect, and catch any exception which can happen for _both_ trying to advance to the next element, and from the operation itself on wishes to execute on a successfully resolved element.

This subtly changes the behavior of `forceOnAll`, but I consider this an alignment to what one expects from `forceOnAll`.

---

I also added `DiggStreams.describeCharacteristics` to get a String description [of the characteristics of a Spliterator](https://docs.oracle.com/javase/8/docs/api/java/util/Spliterator.html#characteristics--), which is represented as a bit-string, and difficult to resolve which actual characteristics are enabled. It is not used by any other code in Digg, but was useful when implementing/debugging the `FlatMapToExceptionSpliterator`, so I decided to include it. It does what it says on the tin, yields a text description, and you should not rely on the String for anything other than information.