### PR TITLE
Combine build and publish to one job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,32 +8,18 @@ jobs:
     strategy:
       matrix:
         java: [ '8', '17', '21' ]
-    name: build java ${{ matrix.java }}
+    name: Build on Java ${{ matrix.java }}
     env:
-      MAVEN_ARGS: --show-version --no-transfer-progress
+      MAVEN_ARGS: --show-version --no-transfer-progress --batch-mode
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Set up java
+      - name: Checkout ${{ github.ref_name }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
           cache: maven
-      - name: Build with Maven
-        run: mvn verify
-
-  publish:
-    needs: build
-    name: Publish ${{ github.ref_name }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Set up Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
-        with:
-          distribution: temurin
-          java-version: '21'
-          cache: "maven"
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PRIVATE }}
           server-id: central
           server-username: MAVEN_CENTRAL_TOKEN_USERNAME
@@ -51,11 +37,10 @@ jobs:
           echo "MAVEN_PROFILES=$profiles" >> $GITHUB_ENV
           version="${GITHUB_REF_NAME}${version_suffix}"
           echo "VERSION=$version" >> $GITHUB_ENV
-      - name: Set Maven version
-        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${VERSION}
-      - name: Build and deploy to Maven Central
-        run: |
-          mvn --batch-mode --no-transfer-progress --activate-profiles ${MAVEN_PROFILES} deploy
+      - name: Set Maven build output version
+        run: mvn versions:set -DnewVersion=${VERSION}
+      - name: Build
+        run: mvn --activate-profiles ${MAVEN_PROFILES} ${{ matrix.java == 8 && 'deploy' || 'verify' }}
         env:
           MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
           MAVEN_CENTRAL_TOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}


### PR DESCRIPTION
Kan dette være et brukbart alternativ for å unngå å kjøre (i praksis) samme bygg to ganger etter hverandre?
Har satt at bygget som gjøres på laveste Java-versjon som skal støttes blir deployet til Central.
