### PR TITLE
Select enum constants from boolean[] or bit mask

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) Posten Norge AS
+    Copyright (C) Posten Bring AS
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-bom</artifactId>
-                <version>2.0.16</version>
+                <version>2.0.17</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.17.0</version>
+            <version>2.21.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>jul-to-slf4j-junit-extension</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -167,11 +167,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.6.2</version>
                     <configuration>
                         <rules>
                             <requireMavenVersion>
-                                <version>3.6.3</version>
+                                <version>3.8.1</version>
                             </requireMavenVersion>
                             <bannedDependencies>
                                 <excludes>
@@ -190,7 +190,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.14.0</version>
+                    <version>3.15.0</version>
                     <configuration>
                         <compilerArgs>
                             <arg>-Xlint</arg>
@@ -199,7 +199,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.3</version>
+                    <version>3.5.5</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -211,7 +211,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.10.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -219,11 +219,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.11.2</version>
+                    <version>3.12.0</version>
                     <configuration>
                         <tags>
                             <tag>
@@ -236,12 +236,12 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.18.0</version>
+                    <version>2.21.0</version>
                     <configuration>
                         <generateBackupPoms>false</generateBackupPoms>
                     </configuration>
@@ -249,7 +249,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.23.1</version>
+                    <version>0.25.4</version>
                     <configuration>
                         <parameter>
                             <includes>

--- a/src/license-header.txt
+++ b/src/license-header.txt
@@ -1,4 +1,4 @@
-Copyright (C) Posten Norge AS
+Copyright (C) Posten Bring AS
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggBase.java
+++ b/src/main/java/no/digipost/DiggBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggCollectors.java
+++ b/src/main/java/no/digipost/DiggCollectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggCompare.java
+++ b/src/main/java/no/digipost/DiggCompare.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggConcurrent.java
+++ b/src/main/java/no/digipost/DiggConcurrent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggEnums.java
+++ b/src/main/java/no/digipost/DiggEnums.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggEnums.java
+++ b/src/main/java/no/digipost/DiggEnums.java
@@ -15,6 +15,7 @@
  */
 package no.digipost;
 
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -23,6 +24,7 @@ import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 /**
@@ -91,6 +93,57 @@ public final class DiggEnums {
     public static <E extends Enum<E>> Stream<E> fromEnumsString(String enumsString, String delimRegex, Predicate<String> included, Function<String, E> convertToEnum) {
         String trimmed = enumsString != null ? enumsString.trim() : "";
         return trimmed.isEmpty() ? Stream.empty() : stream(trimmed.split(delimRegex)).filter(included).map(convertToEnum);
+    }
+
+
+    /**
+     * Select enum constants by mapping <em>indexes</em> of elements in a boolean array which are {@code true} to <em>ordinals</em>
+     * of the enum type.
+     * <p>
+     * It is valid that the enum contains either more or less constants than the given boolean array,
+     * and the resolving will discard any exhaustive elements in either cases. E.g. specifying two booleans
+     * will at most consider two first constants of a given enum type, as well as if the enum only has one
+     * constant, only the first boolean will be processed.
+     *
+     * @param includedOrdinals the boolean array where the <em>indexes</em> of {@code true} elements are mapped
+     *                         to any existing ordinals of the given {@code enumType}
+     * @param enumType the enum type to resolve constants from
+     *
+     * @return the resolved {@code enum} constants
+     */
+    public static <E extends Enum<E>> Stream<E> selectByIndexAsOrdinals(boolean[] includedOrdinals, Class<E> enumType) {
+        BitSet mask = new BitSet(includedOrdinals.length);
+        for (int i = 0; i < includedOrdinals.length; i++) {
+            mask.set(i, includedOrdinals[i]);
+        }
+        return selectByBitmask(mask, enumType);
+    }
+
+
+    /**
+     * Select enum constants by overlaying a bitmask ({@code long}) and selecting the enum <em>by ordinals</em>
+     * which align with the indices of the set bits, mapping the first index to the first enum constant and so
+     * forth. A bitmask of {@code 10110001} (177) will select the first, fifth, sixth, and eight enum constant.
+     * <p>
+     * It is valid both for the enum to contain more constants than the length of the mask,
+     * or less constants than the highest index of a <em>set</em> bit in the given mask,
+     * and the resolving will discard any exhaustive elements in either cases. E.g. a set bit at
+     * index 2 will be ignored for enums with only one constant.
+     *
+     * @param mask the bit mask used for selecting enum constants, the method may mutate this mask
+     * @param enumType the enum type to resolve constants from
+     *
+     * @return the resolved {@code enum} constants
+     */
+    public static <E extends Enum<E>> Stream<E> selectByBitmask(BitSet mask, Class<E> enumType) {
+        if (mask.cardinality() == 0) {
+            return Stream.empty();
+        }
+        E[] candidates = requireNonNull(enumType.getEnumConstants(), enumType + " is not an enum");
+        if (candidates.length == 0) {
+            return Stream.empty();
+        }
+        return mask.get(0, candidates.length).stream().mapToObj(selectedOrdinal -> candidates[selectedOrdinal]);
     }
 
 

--- a/src/main/java/no/digipost/DiggEnums.java
+++ b/src/main/java/no/digipost/DiggEnums.java
@@ -105,18 +105,18 @@ public final class DiggEnums {
      * will at most consider two first constants of a given enum type, as well as if the enum only has one
      * constant, only the first boolean will be processed.
      *
+     * @param enumType the enum type to resolve constants from
      * @param includedOrdinals the boolean array where the <em>indexes</em> of {@code true} elements are mapped
      *                         to any existing ordinals of the given {@code enumType}
-     * @param enumType the enum type to resolve constants from
      *
      * @return the resolved {@code enum} constants
      */
-    public static <E extends Enum<E>> Stream<E> selectByIndexAsOrdinals(boolean[] includedOrdinals, Class<E> enumType) {
+    public static <E extends Enum<E>> Stream<E> selectOrdinalsByIndex(Class<E> enumType, boolean[] includedOrdinals) {
         BitSet mask = new BitSet(includedOrdinals.length);
         for (int i = 0; i < includedOrdinals.length; i++) {
             mask.set(i, includedOrdinals[i]);
         }
-        return selectByBitmask(mask, enumType);
+        return selectOrdinalsByBitmask(enumType, mask);
     }
 
 
@@ -130,12 +130,12 @@ public final class DiggEnums {
      * and the resolving will discard any exhaustive elements in either cases. E.g. a set bit at
      * index 2 will be ignored for enums with only one constant.
      *
-     * @param mask the bit mask used for selecting enum constants, the method may mutate this mask
      * @param enumType the enum type to resolve constants from
+     * @param mask the bit mask used for selecting enum constants, the method may mutate this mask
      *
      * @return the resolved {@code enum} constants
      */
-    public static <E extends Enum<E>> Stream<E> selectByBitmask(BitSet mask, Class<E> enumType) {
+    public static <E extends Enum<E>> Stream<E> selectOrdinalsByBitmask(Class<E> enumType, BitSet mask) {
         if (mask.cardinality() == 0) {
             return Stream.empty();
         }

--- a/src/main/java/no/digipost/DiggExceptions.java
+++ b/src/main/java/no/digipost/DiggExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggIO.java
+++ b/src/main/java/no/digipost/DiggIO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggMaps.java
+++ b/src/main/java/no/digipost/DiggMaps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggOptionals.java
+++ b/src/main/java/no/digipost/DiggOptionals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggPredicates.java
+++ b/src/main/java/no/digipost/DiggPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/DiggStreams.java
+++ b/src/main/java/no/digipost/DiggStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/collection/BatchedIterable.java
+++ b/src/main/java/no/digipost/collection/BatchedIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/collection/ConflictingElementEncountered.java
+++ b/src/main/java/no/digipost/collection/ConflictingElementEncountered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/collection/EnforceAtMostOneElementCollector.java
+++ b/src/main/java/no/digipost/collection/EnforceAtMostOneElementCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/collection/EnforceDistinctFirstTupleElementCollector.java
+++ b/src/main/java/no/digipost/collection/EnforceDistinctFirstTupleElementCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/collection/NonEmptyHeadTailList.java
+++ b/src/main/java/no/digipost/collection/NonEmptyHeadTailList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/collection/NonEmptyList.java
+++ b/src/main/java/no/digipost/collection/NonEmptyList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/collection/SimpleIterator.java
+++ b/src/main/java/no/digipost/collection/SimpleIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/concurrent/CompletionHandler.java
+++ b/src/main/java/no/digipost/concurrent/CompletionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/concurrent/CountDown.java
+++ b/src/main/java/no/digipost/concurrent/CountDown.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/concurrent/OneTimeAssignment.java
+++ b/src/main/java/no/digipost/concurrent/OneTimeAssignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/concurrent/OneTimeToggle.java
+++ b/src/main/java/no/digipost/concurrent/OneTimeToggle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/concurrent/SignalMediator.java
+++ b/src/main/java/no/digipost/concurrent/SignalMediator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/concurrent/TargetState.java
+++ b/src/main/java/no/digipost/concurrent/TargetState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/concurrent/Waiter.java
+++ b/src/main/java/no/digipost/concurrent/Waiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/concurrent/executor/DefaultExecutors.java
+++ b/src/main/java/no/digipost/concurrent/executor/DefaultExecutors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/concurrent/executor/ExternallyManagedExecutorService.java
+++ b/src/main/java/no/digipost/concurrent/executor/ExternallyManagedExecutorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/DecaFunction.java
+++ b/src/main/java/no/digipost/function/DecaFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/HexaFunction.java
+++ b/src/main/java/no/digipost/function/HexaFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/NonaFunction.java
+++ b/src/main/java/no/digipost/function/NonaFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/ObjIntFunction.java
+++ b/src/main/java/no/digipost/function/ObjIntFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/ObjLongFunction.java
+++ b/src/main/java/no/digipost/function/ObjLongFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/OctoFunction.java
+++ b/src/main/java/no/digipost/function/OctoFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/PentaFunction.java
+++ b/src/main/java/no/digipost/function/PentaFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/QuadFunction.java
+++ b/src/main/java/no/digipost/function/QuadFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/SeptiFunction.java
+++ b/src/main/java/no/digipost/function/SeptiFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/SerializableFunction.java
+++ b/src/main/java/no/digipost/function/SerializableFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/ThrowingBiConsumer.java
+++ b/src/main/java/no/digipost/function/ThrowingBiConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/ThrowingBiFunction.java
+++ b/src/main/java/no/digipost/function/ThrowingBiFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/ThrowingConsumer.java
+++ b/src/main/java/no/digipost/function/ThrowingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/ThrowingFunction.java
+++ b/src/main/java/no/digipost/function/ThrowingFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/ThrowingRunnable.java
+++ b/src/main/java/no/digipost/function/ThrowingRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/ThrowingSupplier.java
+++ b/src/main/java/no/digipost/function/ThrowingSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/function/TriFunction.java
+++ b/src/main/java/no/digipost/function/TriFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/io/ConsumingInputStream.java
+++ b/src/main/java/no/digipost/io/ConsumingInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/io/DataSize.java
+++ b/src/main/java/no/digipost/io/DataSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/io/DataSizeUnit.java
+++ b/src/main/java/no/digipost/io/DataSizeUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/io/InputStreamIterator.java
+++ b/src/main/java/no/digipost/io/InputStreamIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/io/LimitedInputStream.java
+++ b/src/main/java/no/digipost/io/LimitedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/io/Zip.java
+++ b/src/main/java/no/digipost/io/Zip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/jdbc/AttributeMapper.java
+++ b/src/main/java/no/digipost/jdbc/AttributeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/jdbc/AttributesRowMapper.java
+++ b/src/main/java/no/digipost/jdbc/AttributesRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/jdbc/BasicColumnMapper.java
+++ b/src/main/java/no/digipost/jdbc/BasicColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/jdbc/ColumnMapper.java
+++ b/src/main/java/no/digipost/jdbc/ColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/jdbc/Mappers.java
+++ b/src/main/java/no/digipost/jdbc/Mappers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/jdbc/NullableColumnMapper.java
+++ b/src/main/java/no/digipost/jdbc/NullableColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/jdbc/RowMapper.java
+++ b/src/main/java/no/digipost/jdbc/RowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/jdbc/SqlArray.java
+++ b/src/main/java/no/digipost/jdbc/SqlArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/stream/CollectorDecorator.java
+++ b/src/main/java/no/digipost/stream/CollectorDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/stream/EmptyResultIfEmptySourceCollector.java
+++ b/src/main/java/no/digipost/stream/EmptyResultIfEmptySourceCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/stream/NonEmptyStream.java
+++ b/src/main/java/no/digipost/stream/NonEmptyStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/stream/ToNonEmptyStreamFunction.java
+++ b/src/main/java/no/digipost/stream/ToNonEmptyStreamFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/text/Regex.java
+++ b/src/main/java/no/digipost/text/Regex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/time/ClockAdjuster.java
+++ b/src/main/java/no/digipost/time/ClockAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/time/ConditionalTimer.java
+++ b/src/main/java/no/digipost/time/ConditionalTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/time/ControllableClock.java
+++ b/src/main/java/no/digipost/time/ControllableClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/time/JavaClockAccessors.java
+++ b/src/main/java/no/digipost/time/JavaClockAccessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/time/JavaClockAdditionalAccessors.java
+++ b/src/main/java/no/digipost/time/JavaClockAdditionalAccessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/time/JavaClockAdjuster.java
+++ b/src/main/java/no/digipost/time/JavaClockAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/time/TimeSpan.java
+++ b/src/main/java/no/digipost/time/TimeSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Decuple.java
+++ b/src/main/java/no/digipost/tuple/Decuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Hextuple.java
+++ b/src/main/java/no/digipost/tuple/Hextuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Nonuple.java
+++ b/src/main/java/no/digipost/tuple/Nonuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Octuple.java
+++ b/src/main/java/no/digipost/tuple/Octuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Pentuple.java
+++ b/src/main/java/no/digipost/tuple/Pentuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Quadruple.java
+++ b/src/main/java/no/digipost/tuple/Quadruple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Septuple.java
+++ b/src/main/java/no/digipost/tuple/Septuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Triple.java
+++ b/src/main/java/no/digipost/tuple/Triple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Tuple.java
+++ b/src/main/java/no/digipost/tuple/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/Tuples.java
+++ b/src/main/java/no/digipost/tuple/Tuples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/ViewableAsDecuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsDecuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/ViewableAsHextuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsHextuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/ViewableAsNonuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsNonuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/ViewableAsOctuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsOctuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/ViewableAsPentuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsPentuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/ViewableAsQuadruple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsQuadruple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/ViewableAsSeptuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsSeptuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/ViewableAsTriple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsTriple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/ViewableAsTuple.java
+++ b/src/main/java/no/digipost/tuple/ViewableAsTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/tuple/XTuple.java
+++ b/src/main/java/no/digipost/tuple/XTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/Assignment.java
+++ b/src/main/java/no/digipost/util/Assignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/AtMostOne.java
+++ b/src/main/java/no/digipost/util/AtMostOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/Attribute.java
+++ b/src/main/java/no/digipost/util/Attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/AttributesMap.java
+++ b/src/main/java/no/digipost/util/AttributesMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/AutoCloseableAdapter.java
+++ b/src/main/java/no/digipost/util/AutoCloseableAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/AutoClosed.java
+++ b/src/main/java/no/digipost/util/AutoClosed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/ChainableAssignment.java
+++ b/src/main/java/no/digipost/util/ChainableAssignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/GetsNamedValue.java
+++ b/src/main/java/no/digipost/util/GetsNamedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/JustA.java
+++ b/src/main/java/no/digipost/util/JustA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/JustALong.java
+++ b/src/main/java/no/digipost/util/JustALong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/SetsNamedValue.java
+++ b/src/main/java/no/digipost/util/SetsNamedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/ThrowingAutoClosed.java
+++ b/src/main/java/no/digipost/util/ThrowingAutoClosed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/ViewableAsOptional.java
+++ b/src/main/java/no/digipost/util/ViewableAsOptional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/bisect/BisectSearch.java
+++ b/src/main/java/no/digipost/util/bisect/BisectSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/bisect/Evaluator.java
+++ b/src/main/java/no/digipost/util/bisect/Evaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/bisect/Suggester.java
+++ b/src/main/java/no/digipost/util/bisect/Suggester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/no/digipost/util/bisect/Suggestion.java
+++ b/src/main/java/no/digipost/util/bisect/Suggestion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggBaseTest.java
+++ b/src/test/java/no/digipost/DiggBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggCollectorsTest.java
+++ b/src/test/java/no/digipost/DiggCollectorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggCompareTest.java
+++ b/src/test/java/no/digipost/DiggCompareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggEnumsTest.java
+++ b/src/test/java/no/digipost/DiggEnumsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggEnumsTest.java
+++ b/src/test/java/no/digipost/DiggEnumsTest.java
@@ -15,6 +15,7 @@
  */
 package no.digipost;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.quicktheories.core.Gen;
 
@@ -37,53 +38,61 @@ import static org.quicktheories.generators.SourceDSL.arrays;
 import static uk.co.probablyfine.matchers.StreamMatchers.contains;
 import static uk.co.probablyfine.matchers.StreamMatchers.empty;
 
-public class DiggEnumsTest {
+class DiggEnumsTest {
 
     enum MyEnum {
         A, AA, ABA, ABC
     }
 
-    private final Gen<MyEnum[]> multipleEnums = arrays().ofClass(arbitrary().enumValues(MyEnum.class), MyEnum.class).withLengthBetween(0, 30);
+    private static final Gen<MyEnum[]> multipleEnums = arrays().ofClass(arbitrary().enumValues(MyEnum.class), MyEnum.class).withLengthBetween(0, 30);
 
-    @Test
-    public void convertFromCommaSeparatedListOfEnumNames() {
-        qt()
-            .forAll(multipleEnums)
-            .asWithPrecursor(DiggEnums::toCommaSeparatedNames)
-            .checkAssert((enums, commaSeparatedNames) -> assertThat(fromCommaSeparatedNames(commaSeparatedNames, MyEnum.class), contains(enums)));
+    @Nested
+    static class FromString {
 
-        qt()
-            .forAll(multipleEnums)
-            .asWithPrecursor(enums -> Stream.of(enums).map(MyEnum::name).collect(joining(" , ", "  ", "   ")))
-            .checkAssert((enums, commaSeparatedNames) -> assertThat(fromCommaSeparatedNames(commaSeparatedNames, MyEnum.class), contains(enums)));
+        @Test
+        void convertFromCommaSeparatedListOfEnumNames() {
+            qt()
+                .forAll(multipleEnums)
+                .asWithPrecursor(DiggEnums::toCommaSeparatedNames)
+                .checkAssert((enums, commaSeparatedNames) -> assertThat(fromCommaSeparatedNames(commaSeparatedNames, MyEnum.class), contains(enums)));
 
+            qt()
+                .forAll(multipleEnums)
+                .asWithPrecursor(enums -> Stream.of(enums).map(MyEnum::name).collect(joining(" , ", "  ", "   ")))
+                .checkAssert((enums, commaSeparatedNames) -> assertThat(fromCommaSeparatedNames(commaSeparatedNames, MyEnum.class), contains(enums)));
+
+        }
+
+        @Test
+        void noEnumsAreFoundInNullString() {
+            assertThat(fromCommaSeparatedNames(null, MyEnum.class), empty());
+        }
     }
 
-    @Test
-    public void noEnumsAreFoundInNullString() {
-        assertThat(fromCommaSeparatedNames(null, MyEnum.class), empty());
-    }
 
-    @Test
-    public void convertToStringOfDelimiterSeparatedStrings() {
-        Function<? super MyEnum, String> lowerCasedEnumName = e -> e.name().toLowerCase();
-        assertThat(toStringOf(lowerCasedEnumName, joining(": ", "[", "]"), A, ABA, AA), is("[a: aba: aa]"));
-    }
+    @Nested
+    static class ToString {
 
-    @Test
-    public void toStringConversionsAreSpecialCasesOfTheGenericBaseCase() {
-        qt()
-            .forAll(multipleEnums)
-            .check(enums -> toCommaSeparatedNames(enums).equals(toStringOf(MyEnum::name, joining(","), enums)));
+        @Test
+        void convertToStringOfDelimiterSeparatedStrings() {
+            Function<? super MyEnum, String> lowerCasedEnumName = e -> e.name().toLowerCase();
+            assertThat(toStringOf(lowerCasedEnumName, joining(": ", "[", "]"), A, ABA, AA), is("[a: aba: aa]"));
+        }
 
-        qt()
-            .forAll(multipleEnums)
-            .check(enums -> toNames(": ", enums).equals(toStringOf(MyEnum::name, joining(": "), enums)));
+        @Test
+        void toStringConversionsAreSpecialCasesOfTheGenericBaseCase() {
+            qt()
+                .forAll(multipleEnums)
+                .check(enums -> toCommaSeparatedNames(enums).equals(toStringOf(MyEnum::name, joining(","), enums)));
 
-        qt()
-            .forAll(multipleEnums)
-            .check(enums -> toStringOf(e -> e.name().toLowerCase(), "#", enums).equals(toStringOf(e -> e.name().toLowerCase(), joining("#"), enums)));
+            qt()
+                .forAll(multipleEnums)
+                .check(enums -> toNames(": ", enums).equals(toStringOf(MyEnum::name, joining(": "), enums)));
 
+            qt()
+                .forAll(multipleEnums)
+                .check(enums -> toStringOf(e -> e.name().toLowerCase(), "#", enums).equals(toStringOf(e -> e.name().toLowerCase(), joining("#"), enums)));
+        }
     }
 
 }

--- a/src/test/java/no/digipost/DiggEnumsTest.java
+++ b/src/test/java/no/digipost/DiggEnumsTest.java
@@ -25,8 +25,8 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
 import static no.digipost.DiggEnums.fromCommaSeparatedNames;
-import static no.digipost.DiggEnums.selectByBitmask;
-import static no.digipost.DiggEnums.selectByIndexAsOrdinals;
+import static no.digipost.DiggEnums.selectOrdinalsByBitmask;
+import static no.digipost.DiggEnums.selectOrdinalsByIndex;
 import static no.digipost.DiggEnums.toCommaSeparatedNames;
 import static no.digipost.DiggEnums.toNames;
 import static no.digipost.DiggEnums.toStringOf;
@@ -107,24 +107,24 @@ class DiggEnumsTest {
 
         @Test
         void noBooleansYieldsNoEmums() {
-            assertThat(selectByIndexAsOrdinals(new boolean[0], MyEnum.class), empty());
+            assertThat(selectOrdinalsByIndex(MyEnum.class, new boolean[0]), empty());
         }
 
         @Test
         void emptyEnumYieldsYieldsNoEmums() {
-            assertThat(selectByIndexAsOrdinals(new boolean[0], Empty.class), empty());
-            assertThat(selectByIndexAsOrdinals(new boolean[] {true}, Empty.class), empty());
-            assertThat(selectByIndexAsOrdinals(new boolean[] {false}, Empty.class), empty());
-            assertThat(selectByIndexAsOrdinals(new boolean[] {false, true}, Empty.class), empty());
-            assertThat(selectByIndexAsOrdinals(new boolean[] {true, true, false}, Empty.class), empty());
+            assertThat(selectOrdinalsByIndex(Empty.class, new boolean[0]), empty());
+            assertThat(selectOrdinalsByIndex(Empty.class, new boolean[] {true}), empty());
+            assertThat(selectOrdinalsByIndex(Empty.class, new boolean[] {false}), empty());
+            assertThat(selectOrdinalsByIndex(Empty.class, new boolean[] {false, true}), empty());
+            assertThat(selectOrdinalsByIndex(Empty.class, new boolean[] {true, true, false}), empty());
         }
 
         @Test
         void resolveSelectionBasedOnBooleanArray() {
-            assertThat(selectByIndexAsOrdinals(new boolean[] {true, false, false, true}, MyEnum.class), contains(A, ABC));
-            assertThat(selectByIndexAsOrdinals(new boolean[] {true, false, false, true, true}, MyEnum.class), contains(A, ABC));
-            assertThat(selectByIndexAsOrdinals(new boolean[] {true, false, false}, MyEnum.class), contains(A));
-            assertThat(selectByIndexAsOrdinals(new boolean[] {true, true, false}, MyEnum.class), contains(A, AA));
+            assertThat(selectOrdinalsByIndex(MyEnum.class, new boolean[] {true, false, false, true}), contains(A, ABC));
+            assertThat(selectOrdinalsByIndex(MyEnum.class, new boolean[] {true, false, false, true, true}), contains(A, ABC));
+            assertThat(selectOrdinalsByIndex(MyEnum.class, new boolean[] {true, false, false}), contains(A));
+            assertThat(selectOrdinalsByIndex(MyEnum.class, new boolean[] {true, true, false}), contains(A, AA));
         }
     }
 
@@ -133,10 +133,10 @@ class DiggEnumsTest {
 
         @Test
         void bitsetsConstructedFromMasksAreTraversedFromLeastSignificantBit() {
-            assertThat(selectByBitmask(BitSet.valueOf(new long[] {0b0001}), MyEnum.class), contains(A));
-            assertThat(selectByBitmask(BitSet.valueOf(new long[] {0b0010}), MyEnum.class), contains(AA));
-            assertThat(selectByBitmask(BitSet.valueOf(new long[] {0b1001}), MyEnum.class), contains(A, ABC));
-            assertThat(selectByBitmask(BitSet.valueOf(new long[] {0b1010}), MyEnum.class), contains(AA, ABC));
+            assertThat(selectOrdinalsByBitmask(MyEnum.class, BitSet.valueOf(new long[] {0b0001})), contains(A));
+            assertThat(selectOrdinalsByBitmask(MyEnum.class, BitSet.valueOf(new long[] {0b0010})), contains(AA));
+            assertThat(selectOrdinalsByBitmask(MyEnum.class, BitSet.valueOf(new long[] {0b1001})), contains(A, ABC));
+            assertThat(selectOrdinalsByBitmask(MyEnum.class, BitSet.valueOf(new long[] {0b1010})), contains(AA, ABC));
         }
     }
 

--- a/src/test/java/no/digipost/DiggEnumsTest.java
+++ b/src/test/java/no/digipost/DiggEnumsTest.java
@@ -24,12 +24,14 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
 import static no.digipost.DiggEnums.fromCommaSeparatedNames;
+import static no.digipost.DiggEnums.selectByIndexAsOrdinals;
 import static no.digipost.DiggEnums.toCommaSeparatedNames;
 import static no.digipost.DiggEnums.toNames;
 import static no.digipost.DiggEnums.toStringOf;
 import static no.digipost.DiggEnumsTest.MyEnum.A;
 import static no.digipost.DiggEnumsTest.MyEnum.AA;
 import static no.digipost.DiggEnumsTest.MyEnum.ABA;
+import static no.digipost.DiggEnumsTest.MyEnum.ABC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.quicktheories.QuickTheory.qt;
@@ -42,6 +44,8 @@ class DiggEnumsTest {
 
     enum MyEnum {
         A, AA, ABA, ABC
+    }
+    enum Empty {
     }
 
     private static final Gen<MyEnum[]> multipleEnums = arrays().ofClass(arbitrary().enumValues(MyEnum.class), MyEnum.class).withLengthBetween(0, 30);
@@ -92,6 +96,33 @@ class DiggEnumsTest {
             qt()
                 .forAll(multipleEnums)
                 .check(enums -> toStringOf(e -> e.name().toLowerCase(), "#", enums).equals(toStringOf(e -> e.name().toLowerCase(), joining("#"), enums)));
+        }
+    }
+
+
+    @Nested
+    static class ResolveFromBooleanArray {
+
+        @Test
+        void noBooleansYieldsNoEmums() {
+            assertThat(selectByIndexAsOrdinals(new boolean[0], MyEnum.class), empty());
+        }
+
+        @Test
+        void emptyEnumYieldsYieldsNoEmums() {
+            assertThat(selectByIndexAsOrdinals(new boolean[0], Empty.class), empty());
+            assertThat(selectByIndexAsOrdinals(new boolean[] {true}, Empty.class), empty());
+            assertThat(selectByIndexAsOrdinals(new boolean[] {false}, Empty.class), empty());
+            assertThat(selectByIndexAsOrdinals(new boolean[] {false, true}, Empty.class), empty());
+            assertThat(selectByIndexAsOrdinals(new boolean[] {true, true, false}, Empty.class), empty());
+        }
+
+        @Test
+        void resolveSelectionBasedOnBooleanArray() {
+            assertThat(selectByIndexAsOrdinals(new boolean[] {true, false, false, true}, MyEnum.class), contains(A, ABC));
+            assertThat(selectByIndexAsOrdinals(new boolean[] {true, false, false, true, true}, MyEnum.class), contains(A, ABC));
+            assertThat(selectByIndexAsOrdinals(new boolean[] {true, false, false}, MyEnum.class), contains(A));
+            assertThat(selectByIndexAsOrdinals(new boolean[] {true, true, false}, MyEnum.class), contains(A, AA));
         }
     }
 

--- a/src/test/java/no/digipost/DiggEnumsTest.java
+++ b/src/test/java/no/digipost/DiggEnumsTest.java
@@ -19,11 +19,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.quicktheories.core.Gen;
 
+import java.util.BitSet;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
 import static no.digipost.DiggEnums.fromCommaSeparatedNames;
+import static no.digipost.DiggEnums.selectByBitmask;
 import static no.digipost.DiggEnums.selectByIndexAsOrdinals;
 import static no.digipost.DiggEnums.toCommaSeparatedNames;
 import static no.digipost.DiggEnums.toNames;
@@ -123,6 +125,18 @@ class DiggEnumsTest {
             assertThat(selectByIndexAsOrdinals(new boolean[] {true, false, false, true, true}, MyEnum.class), contains(A, ABC));
             assertThat(selectByIndexAsOrdinals(new boolean[] {true, false, false}, MyEnum.class), contains(A));
             assertThat(selectByIndexAsOrdinals(new boolean[] {true, true, false}, MyEnum.class), contains(A, AA));
+        }
+    }
+
+    @Nested
+    static class ResolveFromBitmask {
+
+        @Test
+        void bitsetsConstructedFromMasksAreTraversedFromLeastSignificantBit() {
+            assertThat(selectByBitmask(BitSet.valueOf(new long[] {0b0001}), MyEnum.class), contains(A));
+            assertThat(selectByBitmask(BitSet.valueOf(new long[] {0b0010}), MyEnum.class), contains(AA));
+            assertThat(selectByBitmask(BitSet.valueOf(new long[] {0b1001}), MyEnum.class), contains(A, ABC));
+            assertThat(selectByBitmask(BitSet.valueOf(new long[] {0b1010}), MyEnum.class), contains(AA, ABC));
         }
     }
 

--- a/src/test/java/no/digipost/DiggExceptionsTest.java
+++ b/src/test/java/no/digipost/DiggExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggIOTest.java
+++ b/src/test/java/no/digipost/DiggIOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggMapsTest.java
+++ b/src/test/java/no/digipost/DiggMapsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggOptionalsTest.java
+++ b/src/test/java/no/digipost/DiggOptionalsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggPredicatesTest.java
+++ b/src/test/java/no/digipost/DiggPredicatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/DiggStreamsTest.java
+++ b/src/test/java/no/digipost/DiggStreamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/collection/BatchedIterableTest.java
+++ b/src/test/java/no/digipost/collection/BatchedIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/collection/NonEmptyListTest.java
+++ b/src/test/java/no/digipost/collection/NonEmptyListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/collection/SimpleIteratorTest.java
+++ b/src/test/java/no/digipost/collection/SimpleIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/concurrent/CompletionHandlerTest.java
+++ b/src/test/java/no/digipost/concurrent/CompletionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/concurrent/CountDownTest.java
+++ b/src/test/java/no/digipost/concurrent/CountDownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/concurrent/OneTimeAssignmentTest.java
+++ b/src/test/java/no/digipost/concurrent/OneTimeAssignmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/concurrent/OneTimeToggleTest.java
+++ b/src/test/java/no/digipost/concurrent/OneTimeToggleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/concurrent/SignalMediatorTest.java
+++ b/src/test/java/no/digipost/concurrent/SignalMediatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/concurrent/TargetStateTest.java
+++ b/src/test/java/no/digipost/concurrent/TargetStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/function/ThrowingFunctionTest.java
+++ b/src/test/java/no/digipost/function/ThrowingFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/function/ThrowingRunnableTest.java
+++ b/src/test/java/no/digipost/function/ThrowingRunnableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/function/ThrowingSupplierTest.java
+++ b/src/test/java/no/digipost/function/ThrowingSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/io/ConsumingInputStreamTest.java
+++ b/src/test/java/no/digipost/io/ConsumingInputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/io/DataSizeTest.java
+++ b/src/test/java/no/digipost/io/DataSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/io/InputStreamIteratorTest.java
+++ b/src/test/java/no/digipost/io/InputStreamIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/io/LimitedInputStreamThrowingExceptionTest.java
+++ b/src/test/java/no/digipost/io/LimitedInputStreamThrowingExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/io/LimitedInputStreamYieldingEofTest.java
+++ b/src/test/java/no/digipost/io/LimitedInputStreamYieldingEofTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/io/SerializableClassesTest.java
+++ b/src/test/java/no/digipost/io/SerializableClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/jdbc/AttributesRowMapperTest.java
+++ b/src/test/java/no/digipost/jdbc/AttributesRowMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/jdbc/ColumnMapperTest.java
+++ b/src/test/java/no/digipost/jdbc/ColumnMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/jdbc/MappersTest.java
+++ b/src/test/java/no/digipost/jdbc/MappersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/jdbc/ResultSetMock.java
+++ b/src/test/java/no/digipost/jdbc/ResultSetMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/jdbc/RowMapperTest.java
+++ b/src/test/java/no/digipost/jdbc/RowMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/stream/NonEmptyStreamTest.java
+++ b/src/test/java/no/digipost/stream/NonEmptyStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/text/RegexTest.java
+++ b/src/test/java/no/digipost/text/RegexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/time/ConditionalTimerTest.java
+++ b/src/test/java/no/digipost/time/ConditionalTimerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/time/ControllableClockTest.java
+++ b/src/test/java/no/digipost/time/ControllableClockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/time/TimeSpanTest.java
+++ b/src/test/java/no/digipost/time/TimeSpanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/Compound.java
+++ b/src/test/java/no/digipost/tuple/Compound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/DecupleTest.java
+++ b/src/test/java/no/digipost/tuple/DecupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/HextupleTest.java
+++ b/src/test/java/no/digipost/tuple/HextupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/NonupleTest.java
+++ b/src/test/java/no/digipost/tuple/NonupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/OctupleTest.java
+++ b/src/test/java/no/digipost/tuple/OctupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/PentupleTest.java
+++ b/src/test/java/no/digipost/tuple/PentupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/QuadrupleTest.java
+++ b/src/test/java/no/digipost/tuple/QuadrupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/SeptupleTest.java
+++ b/src/test/java/no/digipost/tuple/SeptupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/TripleTest.java
+++ b/src/test/java/no/digipost/tuple/TripleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/TupleTest.java
+++ b/src/test/java/no/digipost/tuple/TupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/TuplesTest.java
+++ b/src/test/java/no/digipost/tuple/TuplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/tuple/XTupleTest.java
+++ b/src/test/java/no/digipost/tuple/XTupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/util/AtMostOneTest.java
+++ b/src/test/java/no/digipost/util/AtMostOneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/util/AttributeTest.java
+++ b/src/test/java/no/digipost/util/AttributeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/util/AttributesMapTest.java
+++ b/src/test/java/no/digipost/util/AttributesMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/util/ChainableAssignmentTest.java
+++ b/src/test/java/no/digipost/util/ChainableAssignmentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/util/DiggMatchers.java
+++ b/src/test/java/no/digipost/util/DiggMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/util/EnforceAtMostOneElementCollectorTest.java
+++ b/src/test/java/no/digipost/util/EnforceAtMostOneElementCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/util/JustALongTest.java
+++ b/src/test/java/no/digipost/util/JustALongTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/util/JustAStringTest.java
+++ b/src/test/java/no/digipost/util/JustAStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/no/digipost/util/bisect/BisectSearchTest.java
+++ b/src/test/java/no/digipost/util/bisect/BisectSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Posten Norge AS
+ * Copyright (C) Posten Bring AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) Posten Norge AS
+# Copyright (C) Posten Bring AS
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (C) Posten Bring AS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.slf4j.simpleLogger.logFile=System.out
+org.slf4j.simpleLogger.defaultLogLevel=warn


### PR DESCRIPTION
Use a bit mask to select constants from an enum, based on which indices which are _set_ (1-bits):
```java
<E extends Enum<E>> Stream<E> DiggEnums.selectOrdinalsByBitmask(Class<E>, BitSet)
```

Use an array of booleans to select constants from an enum, based on which indices which are `true`;
```java
<E extends Enum<E>> Stream<E> DiggEnums.selectOrdinalsByIndex(Class<E>, boolean[])
```

## Use case

This is obviously a bit esoteric functionality. The intention is to ease the use of some APIs which may (probably for valid performance reasons, at least at the time the APIs were defined) return a kind of bitmask to represent a standardized set of possibly set or unset values. 

An example of this is [X509Certificate.getKeyUsage()](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/security/cert/X509Certificate.html#getKeyUsage()), which returns an array of booleans, where each element's position in the array indicate if a known set of ordered values is `true` or `false`. This will enable e.g. the following:

```java
/// Enum representation of the X.509 KeyUsage extension (OID = 2.5.29.15).
/// The order of constants reflect the order of the ASN.1 definition, see
/// [X509Certificate#getKeyUsage()].
enum KeyUsage {
    digitalSignature,
    nonRepudiation,
    keyEncipherment,
    dataEncipherment,
    keyAgreement,
    keyCertSign,
    cRLSign,
    encipherOnly,
    decipherOnly;

    static Stream<KeyUsage> allFrom(X509Certificate certificate) {
        return selectByIndexAsOrdinals(certificate.getKeyUsage(), KeyUsage.class);
    }
}
```

## Note on [EnumSet](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/EnumSet.html)

Java already has a way to represent a set of enum constants using a compact and efficient bitmask, but no way to _construct_ the EnumSet using a bitmask as the source.